### PR TITLE
Fix v15/renaming const variables names

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "C_Cpp.default.cppStandard": "c++11",
+    "C_Cpp.default.cppStandard": "c++17",
     "C_Cpp.default.includePath": [
         "${workspaceFolder}/include",
         "${workspaceFolder}/build",

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -4,5 +4,5 @@
 #
 #    pip-compile --pre bindings/python/requirements.in
 #
-opengeode-core==14.*,>=14.25.1
+opengeode-core==14.*,>=14.25.2rc2
     # via -r bindings/python/requirements.in

--- a/bindings/python/src/common.h
+++ b/bindings/python/src/common.h
@@ -27,7 +27,6 @@
 
 #include <absl/container/fixed_array.h>
 #include <absl/container/inlined_vector.h>
-#include <absl/strings/string_view.h>
 #include <absl/types/span.h>
 
 namespace pybind11
@@ -70,12 +69,5 @@ namespace pybind11
 
             std::vector< typename std::remove_const< Type >::type > cpp_;
         };
-
-        template <>
-        struct type_caster< absl::string_view >
-            : string_caster< absl::string_view, true >
-        {
-        };
-
     } // namespace detail
 } // namespace pybind11

--- a/bindings/python/src/common.h
+++ b/bindings/python/src/common.h
@@ -28,7 +28,6 @@
 #include <absl/container/fixed_array.h>
 #include <absl/container/inlined_vector.h>
 #include <absl/strings/string_view.h>
-#include <absl/types/optional.h>
 #include <absl/types/span.h>
 
 namespace pybind11
@@ -78,10 +77,5 @@ namespace pybind11
         {
         };
 
-        template < typename T >
-        struct type_caster< absl::optional< T > >
-            : public optional_caster< absl::optional< T > >
-        {
-        };
     } // namespace detail
 } // namespace pybind11

--- a/bindings/python/src/explicit/mixin/core/fault.h
+++ b/bindings/python/src/explicit/mixin/core/fault.h
@@ -34,12 +34,12 @@
                                                                                \
     pybind11::enum_< Fault##dimension##D::FAULT_TYPE >(                        \
         fault##dimension##D, "FAULT_TYPE" )                                    \
-        .value( "NO_TYPE", Fault##dimension##D::FAULT_TYPE::NO_TYPE )          \
-        .value( "NORMAL", Fault##dimension##D::FAULT_TYPE::NORMAL )            \
-        .value( "REVERSE", Fault##dimension##D::FAULT_TYPE::REVERSE )          \
-        .value( "STRIKE_SLIP", Fault##dimension##D::FAULT_TYPE::STRIKE_SLIP )  \
-        .value( "LISTRIC", Fault##dimension##D::FAULT_TYPE::LISTRIC )          \
-        .value( "DECOLLEMENT", Fault##dimension##D::FAULT_TYPE::DECOLLEMENT )
+        .value( "NO_TYPE", Fault##dimension##D::FAULT_TYPE::no_type )          \
+        .value( "NORMAL", Fault##dimension##D::FAULT_TYPE::normal )            \
+        .value( "REVERSE", Fault##dimension##D::FAULT_TYPE::reverse )          \
+        .value( "STRIKE_SLIP", Fault##dimension##D::FAULT_TYPE::strike_slip )  \
+        .value( "LISTRIC", Fault##dimension##D::FAULT_TYPE::listric )          \
+        .value( "DECOLLEMENT", Fault##dimension##D::FAULT_TYPE::decollement )
 
 namespace geode
 {

--- a/bindings/python/src/explicit/mixin/core/horizon.h
+++ b/bindings/python/src/explicit/mixin/core/horizon.h
@@ -35,13 +35,13 @@
                                                                                \
     pybind11::enum_< Horizon##dimension##D::HORIZON_TYPE >(                    \
         horizon##dimension##D, "HORIZON_TYPE" )                                \
-        .value( "NO_TYPE", Horizon##dimension##D::HORIZON_TYPE::NO_TYPE )      \
-        .value( "CONFORMAL", Horizon##dimension##D::HORIZON_TYPE::CONFORMAL )  \
+        .value( "NO_TYPE", Horizon##dimension##D::HORIZON_TYPE::no_type )      \
+        .value( "CONFORMAL", Horizon##dimension##D::HORIZON_TYPE::conformal )  \
         .value( "NON_CONFORMAL",                                               \
-            Horizon##dimension##D::HORIZON_TYPE::NON_CONFORMAL )               \
+            Horizon##dimension##D::HORIZON_TYPE::non_conformal )               \
         .value(                                                                \
-            "TOPOGRAPHY", Horizon##dimension##D::HORIZON_TYPE::TOPOGRAPHY )    \
-        .value( "INTRUSION", Horizon##dimension##D::HORIZON_TYPE::INTRUSION )
+            "TOPOGRAPHY", Horizon##dimension##D::HORIZON_TYPE::topography )    \
+        .value( "INTRUSION", Horizon##dimension##D::HORIZON_TYPE::intrusion )
 
 namespace geode
 {

--- a/bindings/python/src/implicit/representation/core/helpers.h
+++ b/bindings/python/src/implicit/representation/core/helpers.h
@@ -59,14 +59,13 @@ namespace geode
                 .def( "repair_horizon_stack_if_possible_3d",
                     &repair_horizon_stack_if_possible< 3 > )
                 .def( "implicit_section_from_cross_section_scalar_field",
-                    []( CrossSection& model,
-                        absl::string_view attribute_name ) {
+                    []( CrossSection& model, std::string_view attribute_name ) {
                         return implicit_section_from_cross_section_scalar_field(
                             model.clone(), attribute_name );
                     } )
                 .def( "implicit_model_from_structural_model_scalar_field",
                     []( StructuralModel& model,
-                        absl::string_view attribute_name ) {
+                        std::string_view attribute_name ) {
                         return implicit_model_from_structural_model_scalar_field(
                             model.clone(), attribute_name );
                     } )

--- a/bindings/python/src/implicit/representation/core/implicit_cross_section.h
+++ b/bindings/python/src/implicit/representation/core/implicit_cross_section.h
@@ -41,7 +41,7 @@ namespace geode
                     const Surface2D&, index_t ) const >(
                     &ImplicitCrossSection::implicit_value ) )
             .def( "implicit_value_from_geometric_point",
-                static_cast< absl::optional< double > (
+                static_cast< std::optional< double > (
                     ImplicitCrossSection::* )(
                     const Surface2D&, const Point2D& ) const >(
                     &ImplicitCrossSection::implicit_value ) )

--- a/bindings/python/src/implicit/representation/core/implicit_structural_model.h
+++ b/bindings/python/src/implicit/representation/core/implicit_structural_model.h
@@ -44,7 +44,7 @@ namespace geode
                     const Block3D&, index_t ) const >(
                     &ImplicitStructuralModel::implicit_value ) )
             .def( "implicit_value_from_geometric_point",
-                static_cast< absl::optional< double > (
+                static_cast< std::optional< double > (
                     ImplicitStructuralModel::* )(
                     const Block3D&, const Point3D& ) const >(
                     &ImplicitStructuralModel::implicit_value ) )

--- a/bindings/python/src/implicit/representation/core/stratigraphic_model.h
+++ b/bindings/python/src/implicit/representation/core/stratigraphic_model.h
@@ -49,7 +49,7 @@ namespace geode
                     const Block3D&, index_t ) const >(
                     &StratigraphicModel::stratigraphic_coordinates ) )
             .def( "stratigraphic_coordinates_from_geometric_point",
-                static_cast< absl::optional< StratigraphicPoint3D > (
+                static_cast< std::optional< StratigraphicPoint3D > (
                     StratigraphicModel::* )( const Block3D&, const Point3D& )
                         const >(
                     &StratigraphicModel::stratigraphic_coordinates ) )
@@ -58,8 +58,7 @@ namespace geode
                     const Block3D&, const Point3D&, index_t ) const >(
                     &StratigraphicModel::stratigraphic_coordinates ) )
             .def( "geometric_coordinates_from_stratigraphic_point",
-                static_cast< absl::optional< Point3D > (
-                    StratigraphicModel::* )(
+                static_cast< std::optional< Point3D > ( StratigraphicModel::* )(
                     const Block3D&, const StratigraphicPoint3D& ) const >(
                     &StratigraphicModel::geometric_coordinates ) )
             .def( "geometric_coordinates_from_stratigraphic_point_and_tetra_id",

--- a/bindings/python/src/implicit/representation/core/stratigraphic_section.h
+++ b/bindings/python/src/implicit/representation/core/stratigraphic_section.h
@@ -49,7 +49,7 @@ namespace geode
                     const Surface2D&, index_t ) const >(
                     &StratigraphicSection::stratigraphic_coordinates ) )
             .def( "stratigraphic_coordinates_from_geometric_point",
-                static_cast< absl::optional< StratigraphicPoint2D > (
+                static_cast< std::optional< StratigraphicPoint2D > (
                     StratigraphicSection::* )(
                     const Surface2D&, const Point2D& ) const >(
                     &StratigraphicSection::stratigraphic_coordinates ) )
@@ -59,7 +59,7 @@ namespace geode
                     const Surface2D&, const Point2D&, index_t ) const >(
                     &StratigraphicSection::stratigraphic_coordinates ) )
             .def( "geometric_coordinates_from_stratigraphic_point",
-                static_cast< absl::optional< Point2D > (
+                static_cast< std::optional< Point2D > (
                     StratigraphicSection::* )(
                     const Surface2D&, const StratigraphicPoint2D& ) const >(
                     &StratigraphicSection::geometric_coordinates ) )

--- a/include/geode/geosciences/explicit/geometry/geographic_coordinate_system_helper.h
+++ b/include/geode/geosciences/explicit/geometry/geographic_coordinate_system_helper.h
@@ -48,80 +48,80 @@ namespace geode
     void assign_edged_curve_geographic_coordinate_system_info(
         const EdgedCurve< dimension >& mesh,
         EdgedCurveBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info );
 
     template < index_t dimension >
     void assign_point_set_geographic_coordinate_system_info(
         const PointSet< dimension >& mesh,
         PointSetBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info );
 
     template < index_t dimension >
     void assign_solid_mesh_geographic_coordinate_system_info(
         const SolidMesh< dimension >& mesh,
         SolidMeshBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info );
 
     template < index_t dimension >
     void assign_surface_mesh_geographic_coordinate_system_info(
         const SurfaceMesh< dimension >& mesh,
         SurfaceMeshBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info );
 
     void opengeode_geosciences_explicit_api
         assign_brep_geographic_coordinate_system_info( const BRep& brep,
             BRepBuilder& builder,
-            absl::string_view crs_name,
+            std::string_view crs_name,
             const GeographicCoordinateSystem3D::Info& info );
 
     void opengeode_geosciences_explicit_api
         assign_section_geographic_coordinate_system_info(
             const Section& section,
             SectionBuilder& builder,
-            absl::string_view crs_name,
+            std::string_view crs_name,
             const GeographicCoordinateSystem2D::Info& info );
 
     template < index_t dimension >
     void convert_edged_curve_coordinate_reference_system(
         const EdgedCurve< dimension >& mesh,
         EdgedCurveBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info );
 
     template < index_t dimension >
     void convert_point_set_coordinate_reference_system(
         const PointSet< dimension >& mesh,
         PointSetBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info );
 
     template < index_t dimension >
     void convert_solid_mesh_coordinate_reference_system(
         const SolidMesh< dimension >& mesh,
         SolidMeshBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info );
 
     template < index_t dimension >
     void convert_surface_mesh_coordinate_reference_system(
         const SurfaceMesh< dimension >& mesh,
         SurfaceMeshBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info );
 
     void opengeode_geosciences_explicit_api
         convert_brep_coordinate_reference_system( const BRep& brep,
             BRepBuilder& builder,
-            absl::string_view crs_name,
+            std::string_view crs_name,
             const GeographicCoordinateSystem3D::Info& info );
 
     void opengeode_geosciences_explicit_api
         convert_section_coordinate_reference_system( const Section& section,
             SectionBuilder& builder,
-            absl::string_view crs_name,
+            std::string_view crs_name,
             const GeographicCoordinateSystem2D::Info& info );
 } // namespace geode

--- a/include/geode/geosciences/explicit/mixin/builder/fault_blocks_builder.h
+++ b/include/geode/geosciences/explicit/mixin/builder/fault_blocks_builder.h
@@ -44,7 +44,7 @@ namespace geode
         void set_fault_block_name( const uuid& id, absl::string_view name );
 
     protected:
-        FaultBlocksBuilder( FaultBlocks< dimension >& fault_blocks )
+        explicit FaultBlocksBuilder( FaultBlocks< dimension >& fault_blocks )
             : fault_blocks_( fault_blocks )
         {
         }

--- a/include/geode/geosciences/explicit/mixin/builder/fault_blocks_builder.h
+++ b/include/geode/geosciences/explicit/mixin/builder/fault_blocks_builder.h
@@ -39,9 +39,9 @@ namespace geode
     class FaultBlocksBuilder
     {
     public:
-        void load_fault_blocks( absl::string_view directory );
+        void load_fault_blocks( std::string_view directory );
 
-        void set_fault_block_name( const uuid& id, absl::string_view name );
+        void set_fault_block_name( const uuid& id, std::string_view name );
 
     protected:
         explicit FaultBlocksBuilder( FaultBlocks< dimension >& fault_blocks )

--- a/include/geode/geosciences/explicit/mixin/builder/faults_builder.h
+++ b/include/geode/geosciences/explicit/mixin/builder/faults_builder.h
@@ -47,7 +47,10 @@ namespace geode
         void set_fault_name( const uuid& id, absl::string_view name );
 
     protected:
-        FaultsBuilder( Faults< dimension >& faults ) : faults_( faults ) {}
+        explicit FaultsBuilder( Faults< dimension >& faults )
+            : faults_( faults )
+        {
+        }
 
         const uuid& create_fault();
 

--- a/include/geode/geosciences/explicit/mixin/builder/faults_builder.h
+++ b/include/geode/geosciences/explicit/mixin/builder/faults_builder.h
@@ -39,12 +39,12 @@ namespace geode
     class FaultsBuilder
     {
     public:
-        void load_faults( absl::string_view directory );
+        void load_faults( std::string_view directory );
 
         void set_fault_type( const uuid& fault_id,
             typename Fault< dimension >::FAULT_TYPE type );
 
-        void set_fault_name( const uuid& id, absl::string_view name );
+        void set_fault_name( const uuid& id, std::string_view name );
 
     protected:
         explicit FaultsBuilder( Faults< dimension >& faults )

--- a/include/geode/geosciences/explicit/mixin/builder/horizons_builder.h
+++ b/include/geode/geosciences/explicit/mixin/builder/horizons_builder.h
@@ -47,7 +47,7 @@ namespace geode
         void set_horizon_name( const uuid& id, absl::string_view name );
 
     protected:
-        HorizonsBuilder( Horizons< dimension >& horizons )
+        explicit HorizonsBuilder( Horizons< dimension >& horizons )
             : horizons_( horizons )
         {
         }

--- a/include/geode/geosciences/explicit/mixin/builder/horizons_builder.h
+++ b/include/geode/geosciences/explicit/mixin/builder/horizons_builder.h
@@ -39,12 +39,12 @@ namespace geode
     class HorizonsBuilder
     {
     public:
-        void load_horizons( absl::string_view directory );
+        void load_horizons( std::string_view directory );
 
         void set_horizon_type( const uuid& horizon_id,
             typename Horizon< dimension >::HORIZON_TYPE type );
 
-        void set_horizon_name( const uuid& id, absl::string_view name );
+        void set_horizon_name( const uuid& id, std::string_view name );
 
     protected:
         explicit HorizonsBuilder( Horizons< dimension >& horizons )

--- a/include/geode/geosciences/explicit/mixin/builder/stratigraphic_units_builder.h
+++ b/include/geode/geosciences/explicit/mixin/builder/stratigraphic_units_builder.h
@@ -39,10 +39,10 @@ namespace geode
     class StratigraphicUnitsBuilder
     {
     public:
-        void load_stratigraphic_units( absl::string_view directory );
+        void load_stratigraphic_units( std::string_view directory );
 
         void set_stratigraphic_unit_name(
-            const uuid& id, absl::string_view name );
+            const uuid& id, std::string_view name );
 
     protected:
         explicit StratigraphicUnitsBuilder(

--- a/include/geode/geosciences/explicit/mixin/builder/stratigraphic_units_builder.h
+++ b/include/geode/geosciences/explicit/mixin/builder/stratigraphic_units_builder.h
@@ -45,7 +45,7 @@ namespace geode
             const uuid& id, absl::string_view name );
 
     protected:
-        StratigraphicUnitsBuilder(
+        explicit StratigraphicUnitsBuilder(
             StratigraphicUnits< dimension >& stratigraphic_units )
             : stratigraphic_units_( stratigraphic_units )
         {

--- a/include/geode/geosciences/explicit/mixin/core/fault.h
+++ b/include/geode/geosciences/explicit/mixin/core/fault.h
@@ -53,12 +53,12 @@ namespace geode
         enum struct FAULT_TYPE
         {
             /// Default value - No fault type defined
-            NO_TYPE,
-            NORMAL,
-            REVERSE,
-            STRIKE_SLIP,
-            LISTRIC,
-            DECOLLEMENT
+            no_type,
+            normal,
+            reverse,
+            strike_slip,
+            listric,
+            decollement
         };
 
     public:

--- a/include/geode/geosciences/explicit/mixin/core/fault.h
+++ b/include/geode/geosciences/explicit/mixin/core/fault.h
@@ -89,7 +89,7 @@ namespace geode
 
         void set_type( FAULT_TYPE type, FaultsBuilderKey );
 
-        void set_fault_name( absl::string_view name, FaultsBuilderKey )
+        void set_fault_name( std::string_view name, FaultsBuilderKey )
         {
             this->set_name( name );
         }

--- a/include/geode/geosciences/explicit/mixin/core/fault_block.h
+++ b/include/geode/geosciences/explicit/mixin/core/fault_block.h
@@ -71,7 +71,7 @@ namespace geode
         FaultBlock( FaultBlocksKey ) : FaultBlock(){};
 
         void set_fault_block_name(
-            absl::string_view name, FaultBlocksBuilderKey )
+            std::string_view name, FaultBlocksBuilderKey )
         {
             this->set_name( name );
         }

--- a/include/geode/geosciences/explicit/mixin/core/fault_blocks.h
+++ b/include/geode/geosciences/explicit/mixin/core/fault_blocks.h
@@ -94,7 +94,7 @@ namespace geode
 
         FaultBlockRange fault_blocks() const;
 
-        void save_fault_blocks( absl::string_view directory ) const;
+        void save_fault_blocks( std::string_view directory ) const;
 
     protected:
         friend class FaultBlocksBuilder< dimension >;
@@ -129,7 +129,7 @@ namespace geode
 
         void delete_fault_block( const FaultBlock< dimension >& fault_block );
 
-        void load_fault_blocks( absl::string_view directory );
+        void load_fault_blocks( std::string_view directory );
 
         ModifiableFaultBlockRange modifiable_fault_blocks();
 

--- a/include/geode/geosciences/explicit/mixin/core/faults.h
+++ b/include/geode/geosciences/explicit/mixin/core/faults.h
@@ -94,7 +94,7 @@ namespace geode
 
         FaultRange faults() const;
 
-        void save_faults( absl::string_view directory ) const;
+        void save_faults( std::string_view directory ) const;
 
     protected:
         friend class FaultsBuilder< dimension >;
@@ -135,7 +135,7 @@ namespace geode
 
         void delete_fault( const Fault< dimension >& fault );
 
-        void load_faults( absl::string_view directory );
+        void load_faults( std::string_view directory );
 
         ModifiableFaultRange modifiable_faults();
 

--- a/include/geode/geosciences/explicit/mixin/core/horizon.h
+++ b/include/geode/geosciences/explicit/mixin/core/horizon.h
@@ -53,11 +53,11 @@ namespace geode
         enum struct HORIZON_TYPE
         {
             /// Default value - No horizon type defined
-            NO_TYPE,
-            CONFORMAL,
-            NON_CONFORMAL,
-            TOPOGRAPHY,
-            INTRUSION
+            no_type,
+            conformal,
+            non_conformal,
+            topography,
+            intrusion
         };
 
     public:

--- a/include/geode/geosciences/explicit/mixin/core/horizon.h
+++ b/include/geode/geosciences/explicit/mixin/core/horizon.h
@@ -88,7 +88,7 @@ namespace geode
 
         void set_type( HORIZON_TYPE type, HorizonsBuilderKey );
 
-        void set_horizon_name( absl::string_view name, HorizonsBuilderKey )
+        void set_horizon_name( std::string_view name, HorizonsBuilderKey )
         {
             this->set_name( name );
         }

--- a/include/geode/geosciences/explicit/mixin/core/horizons.h
+++ b/include/geode/geosciences/explicit/mixin/core/horizons.h
@@ -94,7 +94,7 @@ namespace geode
 
         HorizonRange horizons() const;
 
-        void save_horizons( absl::string_view directory ) const;
+        void save_horizons( std::string_view directory ) const;
 
     protected:
         friend class HorizonsBuilder< dimension >;
@@ -136,7 +136,7 @@ namespace geode
 
         void delete_horizon( const Horizon< dimension >& horizon );
 
-        void load_horizons( absl::string_view directory );
+        void load_horizons( std::string_view directory );
 
         ModifiableHorizonRange modifiable_horizons();
 

--- a/include/geode/geosciences/explicit/mixin/core/stratigraphic_unit.h
+++ b/include/geode/geosciences/explicit/mixin/core/stratigraphic_unit.h
@@ -70,7 +70,7 @@ namespace geode
         StratigraphicUnit( StratigraphicUnitsKey ) : StratigraphicUnit() {}
 
         void set_stratigraphic_unit_name(
-            absl::string_view name, StratigraphicUnitsBuilderKey )
+            std::string_view name, StratigraphicUnitsBuilderKey )
         {
             this->set_name( name );
         }

--- a/include/geode/geosciences/explicit/mixin/core/stratigraphic_units.h
+++ b/include/geode/geosciences/explicit/mixin/core/stratigraphic_units.h
@@ -100,7 +100,7 @@ namespace geode
 
         StratigraphicUnitRange stratigraphic_units() const;
 
-        void save_stratigraphic_units( absl::string_view directory ) const;
+        void save_stratigraphic_units( std::string_view directory ) const;
 
     protected:
         friend class StratigraphicUnitsBuilder< dimension >;
@@ -139,7 +139,7 @@ namespace geode
         void delete_stratigraphic_unit(
             const StratigraphicUnit< dimension >& stratigraphic_unit );
 
-        void load_stratigraphic_units( absl::string_view directory );
+        void load_stratigraphic_units( std::string_view directory );
 
         ModifiableStratigraphicUnitRange modifiable_stratigraphic_units();
 

--- a/include/geode/geosciences/explicit/representation/builder/cross_section_builder.h
+++ b/include/geode/geosciences/explicit/representation/builder/cross_section_builder.h
@@ -58,7 +58,7 @@ namespace geode
         OPENGEODE_DISABLE_COPY_AND_MOVE( CrossSectionBuilder );
 
     public:
-        CrossSectionBuilder( CrossSection& cross_section );
+        explicit CrossSectionBuilder( CrossSection& cross_section );
 
         ModelCopyMapping copy( const CrossSection& cross_section );
 

--- a/include/geode/geosciences/explicit/representation/builder/structural_model_builder.h
+++ b/include/geode/geosciences/explicit/representation/builder/structural_model_builder.h
@@ -58,7 +58,7 @@ namespace geode
         OPENGEODE_DISABLE_COPY_AND_MOVE( StructuralModelBuilder );
 
     public:
-        StructuralModelBuilder( StructuralModel& structural_model );
+        explicit StructuralModelBuilder( StructuralModel& structural_model );
 
         ModelCopyMapping copy( const StructuralModel& structural_model );
 

--- a/include/geode/geosciences/explicit/representation/core/cross_section.h
+++ b/include/geode/geosciences/explicit/representation/core/cross_section.h
@@ -154,12 +154,12 @@ namespace geode
 
         CrossSection clone() const;
 
-        static constexpr absl::string_view native_extension_static()
+        static constexpr std::string_view native_extension_static()
         {
             return "og_xsctn";
         }
 
-        absl::string_view native_extension() const
+        std::string_view native_extension() const
         {
             return native_extension_static();
         }

--- a/include/geode/geosciences/explicit/representation/core/structural_model.h
+++ b/include/geode/geosciences/explicit/representation/core/structural_model.h
@@ -157,12 +157,12 @@ namespace geode
 
         StructuralModel clone() const;
 
-        static constexpr absl::string_view native_extension_static()
+        static constexpr std::string_view native_extension_static()
         {
             return "og_strm";
         }
 
-        absl::string_view native_extension() const
+        std::string_view native_extension() const
         {
             return native_extension_static();
         }

--- a/include/geode/geosciences/explicit/representation/io/cross_section_input.h
+++ b/include/geode/geosciences/explicit/representation/io/cross_section_input.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <absl/strings/string_view.h>
+#include <string_view>
 
 #include <geode/basic/factory.h>
 
@@ -45,7 +45,7 @@ namespace geode
      * @param[in] filename Path to the file to load.
      */
     CrossSection opengeode_geosciences_explicit_api load_cross_section(
-        absl::string_view filename );
+        std::string_view filename );
 
     class CrossSectionInput : public Input< CrossSection >
     {
@@ -55,18 +55,18 @@ namespace geode
         using typename Base::MissingFiles;
 
     protected:
-        explicit CrossSectionInput( absl::string_view filename )
+        explicit CrossSectionInput( std::string_view filename )
             : Base{ filename }
         {
         }
     };
 
     CrossSectionInput::MissingFiles opengeode_geosciences_explicit_api
-        check_cross_section_missing_files( absl::string_view filename );
+        check_cross_section_missing_files( std::string_view filename );
 
     bool opengeode_geosciences_explicit_api is_cross_section_loadable(
-        absl::string_view filename );
+        std::string_view filename );
 
     using CrossSectionInputFactory =
-        Factory< std::string, CrossSectionInput, absl::string_view >;
+        Factory< std::string, CrossSectionInput, std::string_view >;
 } // namespace geode

--- a/include/geode/geosciences/explicit/representation/io/cross_section_output.h
+++ b/include/geode/geosciences/explicit/representation/io/cross_section_output.h
@@ -24,9 +24,8 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/factory.h>
 
@@ -49,7 +48,7 @@ namespace geode
      */
     std::vector< std::string >
         opengeode_geosciences_explicit_api save_cross_section(
-            const CrossSection& cross_section, absl::string_view filename );
+            const CrossSection& cross_section, std::string_view filename );
 
     class CrossSectionOutput : public Output< CrossSection >
     {
@@ -57,15 +56,15 @@ namespace geode
         virtual ~CrossSectionOutput() = default;
 
     protected:
-        explicit CrossSectionOutput( absl::string_view filename )
+        explicit CrossSectionOutput( std::string_view filename )
             : Output< CrossSection >{ filename }
         {
         }
     };
 
     bool opengeode_geosciences_explicit_api is_cross_section_saveable(
-        const CrossSection& cross_section, absl::string_view filename );
+        const CrossSection& cross_section, std::string_view filename );
 
     using CrossSectionOutputFactory =
-        Factory< std::string, CrossSectionOutput, absl::string_view >;
+        Factory< std::string, CrossSectionOutput, std::string_view >;
 } // namespace geode

--- a/include/geode/geosciences/explicit/representation/io/cross_section_output.h
+++ b/include/geode/geosciences/explicit/representation/io/cross_section_output.h
@@ -57,7 +57,7 @@ namespace geode
         virtual ~CrossSectionOutput() = default;
 
     protected:
-        CrossSectionOutput( absl::string_view filename )
+        explicit CrossSectionOutput( absl::string_view filename )
             : Output< CrossSection >{ filename }
         {
         }

--- a/include/geode/geosciences/explicit/representation/io/geode/geode_cross_section_input.h
+++ b/include/geode/geosciences/explicit/representation/io/geode/geode_cross_section_input.h
@@ -32,15 +32,15 @@ namespace geode
         : public CrossSectionInput
     {
     public:
-        explicit OpenGeodeCrossSectionInput( absl::string_view filename );
+        explicit OpenGeodeCrossSectionInput( std::string_view filename );
 
-        static absl::string_view extension()
+        static std::string_view extension()
         {
             return CrossSection::native_extension_static();
         }
 
         void load_cross_section_files(
-            CrossSection& cross_section, absl::string_view directory );
+            CrossSection& cross_section, std::string_view directory );
 
         CrossSection read() final;
     };

--- a/include/geode/geosciences/explicit/representation/io/geode/geode_cross_section_input.h
+++ b/include/geode/geosciences/explicit/representation/io/geode/geode_cross_section_input.h
@@ -32,7 +32,7 @@ namespace geode
         : public CrossSectionInput
     {
     public:
-        OpenGeodeCrossSectionInput( absl::string_view filename );
+        explicit OpenGeodeCrossSectionInput( absl::string_view filename );
 
         static absl::string_view extension()
         {

--- a/include/geode/geosciences/explicit/representation/io/geode/geode_cross_section_output.h
+++ b/include/geode/geosciences/explicit/representation/io/geode/geode_cross_section_output.h
@@ -40,7 +40,7 @@ namespace geode
         : public CrossSectionOutput
     {
     public:
-        OpenGeodeCrossSectionOutput( absl::string_view filename );
+        explicit OpenGeodeCrossSectionOutput( absl::string_view filename );
 
         static absl::string_view extension()
         {

--- a/include/geode/geosciences/explicit/representation/io/geode/geode_cross_section_output.h
+++ b/include/geode/geosciences/explicit/representation/io/geode/geode_cross_section_output.h
@@ -40,15 +40,15 @@ namespace geode
         : public CrossSectionOutput
     {
     public:
-        explicit OpenGeodeCrossSectionOutput( absl::string_view filename );
+        explicit OpenGeodeCrossSectionOutput( std::string_view filename );
 
-        static absl::string_view extension()
+        static std::string_view extension()
         {
             return CrossSection::native_extension_static();
         }
 
         void save_cross_section_files( const CrossSection& cross_section,
-            absl::string_view directory ) const;
+            std::string_view directory ) const;
 
         void archive_cross_section_files( const ZipFile& zip_writer ) const;
 

--- a/include/geode/geosciences/explicit/representation/io/geode/geode_structural_model_input.h
+++ b/include/geode/geosciences/explicit/representation/io/geode/geode_structural_model_input.h
@@ -32,15 +32,15 @@ namespace geode
         : public StructuralModelInput
     {
     public:
-        explicit OpenGeodeStructuralModelInput( absl::string_view filename );
+        explicit OpenGeodeStructuralModelInput( std::string_view filename );
 
-        static absl::string_view extension()
+        static std::string_view extension()
         {
             return StructuralModel::native_extension_static();
         }
 
         void load_structural_model_files(
-            StructuralModel& structural_model, absl::string_view directory );
+            StructuralModel& structural_model, std::string_view directory );
 
         StructuralModel read() final;
     };

--- a/include/geode/geosciences/explicit/representation/io/geode/geode_structural_model_input.h
+++ b/include/geode/geosciences/explicit/representation/io/geode/geode_structural_model_input.h
@@ -32,7 +32,7 @@ namespace geode
         : public StructuralModelInput
     {
     public:
-        OpenGeodeStructuralModelInput( absl::string_view filename );
+        explicit OpenGeodeStructuralModelInput( absl::string_view filename );
 
         static absl::string_view extension()
         {

--- a/include/geode/geosciences/explicit/representation/io/geode/geode_structural_model_output.h
+++ b/include/geode/geosciences/explicit/representation/io/geode/geode_structural_model_output.h
@@ -40,16 +40,16 @@ namespace geode
         final : public StructuralModelOutput
     {
     public:
-        explicit OpenGeodeStructuralModelOutput( absl::string_view filename );
+        explicit OpenGeodeStructuralModelOutput( std::string_view filename );
 
-        static absl::string_view extension()
+        static std::string_view extension()
         {
             return StructuralModel::native_extension_static();
         }
 
         void save_structural_model_files(
             const StructuralModel& structural_model,
-            absl::string_view directory ) const;
+            std::string_view directory ) const;
 
         void archive_structural_model_files( const ZipFile& zip_writer ) const;
 

--- a/include/geode/geosciences/explicit/representation/io/geode/geode_structural_model_output.h
+++ b/include/geode/geosciences/explicit/representation/io/geode/geode_structural_model_output.h
@@ -40,7 +40,7 @@ namespace geode
         final : public StructuralModelOutput
     {
     public:
-        OpenGeodeStructuralModelOutput( absl::string_view filename );
+        explicit OpenGeodeStructuralModelOutput( absl::string_view filename );
 
         static absl::string_view extension()
         {

--- a/include/geode/geosciences/explicit/representation/io/structural_model_input.h
+++ b/include/geode/geosciences/explicit/representation/io/structural_model_input.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <absl/strings/string_view.h>
+#include <string_view>
 
 #include <geode/basic/factory.h>
 
@@ -45,7 +45,7 @@ namespace geode
      * @param[in] filename Path to the file to load.
      */
     StructuralModel opengeode_geosciences_explicit_api load_structural_model(
-        absl::string_view filename );
+        std::string_view filename );
 
     class StructuralModelInput : public Input< StructuralModel >
     {
@@ -55,18 +55,18 @@ namespace geode
         using typename Base::MissingFiles;
 
     protected:
-        explicit StructuralModelInput( absl::string_view filename )
+        explicit StructuralModelInput( std::string_view filename )
             : Base{ filename }
         {
         }
     };
 
     StructuralModelInput::MissingFiles opengeode_geosciences_explicit_api
-        check_structural_model_missing_files( absl::string_view filename );
+        check_structural_model_missing_files( std::string_view filename );
 
     bool opengeode_geosciences_explicit_api is_structural_model_loadable(
-        absl::string_view filename );
+        std::string_view filename );
 
     using StructuralModelInputFactory =
-        Factory< std::string, StructuralModelInput, absl::string_view >;
+        Factory< std::string, StructuralModelInput, std::string_view >;
 } // namespace geode

--- a/include/geode/geosciences/explicit/representation/io/structural_model_output.h
+++ b/include/geode/geosciences/explicit/representation/io/structural_model_output.h
@@ -24,9 +24,8 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/factory.h>
 
@@ -49,7 +48,7 @@ namespace geode
      */
     std::vector< std::string > opengeode_geosciences_explicit_api
         save_structural_model( const StructuralModel& structural_model,
-            absl::string_view filename );
+            std::string_view filename );
 
     class StructuralModelOutput : public Output< StructuralModel >
     {
@@ -57,15 +56,15 @@ namespace geode
         virtual ~StructuralModelOutput() = default;
 
     protected:
-        explicit StructuralModelOutput( absl::string_view filename )
+        explicit StructuralModelOutput( std::string_view filename )
             : Output< StructuralModel >{ filename }
         {
         }
     };
 
     bool opengeode_geosciences_explicit_api is_structural_model_saveable(
-        const StructuralModel& structural_model, absl::string_view filename );
+        const StructuralModel& structural_model, std::string_view filename );
 
     using StructuralModelOutputFactory =
-        Factory< std::string, StructuralModelOutput, absl::string_view >;
+        Factory< std::string, StructuralModelOutput, std::string_view >;
 } // namespace geode

--- a/include/geode/geosciences/explicit/representation/io/structural_model_output.h
+++ b/include/geode/geosciences/explicit/representation/io/structural_model_output.h
@@ -57,7 +57,7 @@ namespace geode
         virtual ~StructuralModelOutput() = default;
 
     protected:
-        StructuralModelOutput( absl::string_view filename )
+        explicit StructuralModelOutput( absl::string_view filename )
             : Output< StructuralModel >{ filename }
         {
         }

--- a/include/geode/geosciences/implicit/geometry/stratigraphic_point.h
+++ b/include/geode/geosciences/implicit/geometry/stratigraphic_point.h
@@ -51,7 +51,8 @@ namespace geode
               implicit_value_{ implicit_value }
         {
         }
-        StratigraphicPoint( const std::array< double, dimension >& values )
+        explicit StratigraphicPoint(
+            const std::array< double, dimension >& values )
             : implicit_value_{ values[dimension - 1] }
         {
             for( const auto d : LRange{ location_dim } )

--- a/include/geode/geosciences/implicit/mixin/builder/stratigraphic_relationships_builder.h
+++ b/include/geode/geosciences/implicit/mixin/builder/stratigraphic_relationships_builder.h
@@ -36,7 +36,7 @@ namespace geode
     class opengeode_geosciences_implicit_api StratigraphicRelationshipsBuilder
     {
     public:
-        StratigraphicRelationshipsBuilder(
+        explicit StratigraphicRelationshipsBuilder(
             StratigraphicRelationships& relationships );
 
         /*!

--- a/include/geode/geosciences/implicit/mixin/builder/stratigraphic_relationships_builder.h
+++ b/include/geode/geosciences/implicit/mixin/builder/stratigraphic_relationships_builder.h
@@ -64,7 +64,7 @@ namespace geode
         void copy_stratigraphic_relationships( const ModelCopyMapping& mapping,
             const StratigraphicRelationships& relationships );
 
-        void load_stratigraphic_relationships( absl::string_view directory );
+        void load_stratigraphic_relationships( std::string_view directory );
 
     protected:
         /*!

--- a/include/geode/geosciences/implicit/mixin/core/stratigraphic_relationships.h
+++ b/include/geode/geosciences/implicit/mixin/core/stratigraphic_relationships.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <geode/basic/passkey.h>
 #include <geode/basic/pimpl.h>
 
@@ -56,9 +58,9 @@ namespace geode
 
         bool is_above( const uuid& above, const uuid& under ) const;
 
-        absl::optional< uuid > above( const uuid& element ) const;
+        std::optional< uuid > above( const uuid& element ) const;
 
-        absl::optional< uuid > under( const uuid& element ) const;
+        std::optional< uuid > under( const uuid& element ) const;
 
         void save_stratigraphic_relationships(
             absl::string_view directory ) const;

--- a/include/geode/geosciences/implicit/mixin/core/stratigraphic_relationships.h
+++ b/include/geode/geosciences/implicit/mixin/core/stratigraphic_relationships.h
@@ -63,7 +63,7 @@ namespace geode
         std::optional< uuid > under( const uuid& element ) const;
 
         void save_stratigraphic_relationships(
-            absl::string_view directory ) const;
+            std::string_view directory ) const;
 
     public:
         /*!
@@ -115,7 +115,7 @@ namespace geode
             StratigraphicRelationshipsBuilderKey );
 
         void load_stratigraphic_relationships(
-            absl::string_view directory, StratigraphicRelationshipsBuilderKey );
+            std::string_view directory, StratigraphicRelationshipsBuilderKey );
 
     protected:
         StratigraphicRelationships(

--- a/include/geode/geosciences/implicit/representation/builder/horizons_stack_builder.h
+++ b/include/geode/geosciences/implicit/representation/builder/horizons_stack_builder.h
@@ -65,7 +65,8 @@ namespace geode
         };
 
     public:
-        HorizonsStackBuilder( HorizonsStack< dimension >& horizons_stack );
+        explicit HorizonsStackBuilder(
+            HorizonsStack< dimension >& horizons_stack );
         HorizonsStackBuilder( HorizonsStackBuilder< dimension >&& ) = default;
 
         ModelCopyMapping copy(

--- a/include/geode/geosciences/implicit/representation/builder/implicit_cross_section_builder.h
+++ b/include/geode/geosciences/implicit/representation/builder/implicit_cross_section_builder.h
@@ -44,7 +44,8 @@ namespace geode
         : public CrossSectionBuilder
     {
     public:
-        ImplicitCrossSectionBuilder( ImplicitCrossSection& implicit_section );
+        explicit ImplicitCrossSectionBuilder(
+            ImplicitCrossSection& implicit_section );
 
         ModelCopyMapping copy( const ImplicitCrossSection& implicit_model );
 

--- a/include/geode/geosciences/implicit/representation/builder/implicit_structural_model_builder.h
+++ b/include/geode/geosciences/implicit/representation/builder/implicit_structural_model_builder.h
@@ -44,7 +44,7 @@ namespace geode
         : public StructuralModelBuilder
     {
     public:
-        ImplicitStructuralModelBuilder(
+        explicit ImplicitStructuralModelBuilder(
             ImplicitStructuralModel& implicit_model );
 
         ModelCopyMapping copy( const ImplicitStructuralModel& implicit_model );

--- a/include/geode/geosciences/implicit/representation/builder/stratigraphic_model_builder.h
+++ b/include/geode/geosciences/implicit/representation/builder/stratigraphic_model_builder.h
@@ -44,7 +44,8 @@ namespace geode
         : public ImplicitStructuralModelBuilder
     {
     public:
-        StratigraphicModelBuilder( StratigraphicModel& stratigraphic_model_ );
+        explicit StratigraphicModelBuilder(
+            StratigraphicModel& stratigraphic_model_ );
 
         ModelCopyMapping copy( const StratigraphicModel& implicit_model );
 

--- a/include/geode/geosciences/implicit/representation/builder/stratigraphic_section_builder.h
+++ b/include/geode/geosciences/implicit/representation/builder/stratigraphic_section_builder.h
@@ -44,7 +44,7 @@ namespace geode
         : public ImplicitCrossSectionBuilder
     {
     public:
-        StratigraphicSectionBuilder(
+        explicit StratigraphicSectionBuilder(
             StratigraphicSection& stratigraphic_section );
 
         ModelCopyMapping copy(

--- a/include/geode/geosciences/implicit/representation/core/detail/helpers.h
+++ b/include/geode/geosciences/implicit/representation/core/detail/helpers.h
@@ -58,20 +58,20 @@ namespace geode
             rescale_implicit_value_to_bbox_scale( StratigraphicModel& model );
 
         void opengeode_geosciences_implicit_api save_stratigraphic_surfaces(
-            const StratigraphicSection& section, absl::string_view prefix );
+            const StratigraphicSection& section, std::string_view prefix );
 
         void opengeode_geosciences_implicit_api save_stratigraphic_blocks(
-            const StratigraphicModel& model, absl::string_view prefix );
+            const StratigraphicModel& model, std::string_view prefix );
 
         ImplicitCrossSection opengeode_geosciences_implicit_api
             implicit_section_from_cross_section_scalar_field(
                 CrossSection&& section,
-                absl::string_view scalar_attribute_name );
+                std::string_view scalar_attribute_name );
 
         ImplicitStructuralModel opengeode_geosciences_implicit_api
             implicit_model_from_structural_model_scalar_field(
                 StructuralModel&& model,
-                absl::string_view scalar_attribute_name );
+                std::string_view scalar_attribute_name );
 
         StratigraphicModel opengeode_geosciences_implicit_api
             stratigraphic_model_from_implicit_model_and_coords(

--- a/include/geode/geosciences/implicit/representation/core/horizons_stack.h
+++ b/include/geode/geosciences/implicit/representation/core/horizons_stack.h
@@ -69,14 +69,14 @@ namespace geode
 
         HorizonsStack< dimension > clone() const;
 
-        static absl::string_view native_extension_static()
+        static std::string_view native_extension_static()
         {
             static const auto extension =
                 absl::StrCat( "og_hst", dimension, "d" );
             return extension;
         }
 
-        absl::string_view native_extension() const
+        std::string_view native_extension() const
         {
             return native_extension_static();
         }

--- a/include/geode/geosciences/implicit/representation/core/implicit_cross_section.h
+++ b/include/geode/geosciences/implicit/representation/core/implicit_cross_section.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <geode/basic/pimpl.h>
 
 #include <geode/geosciences/explicit/representation/core/cross_section.h>

--- a/include/geode/geosciences/implicit/representation/core/implicit_cross_section.h
+++ b/include/geode/geosciences/implicit/representation/core/implicit_cross_section.h
@@ -52,7 +52,7 @@ namespace geode
         PASSKEY( ImplicitCrossSectionBuilder, ImplicitCrossSectionBuilderKey );
 
     public:
-        static constexpr auto implicit_attribute_name =
+        static constexpr auto IMPLICIT_ATTRIBUTE_NAME =
             "geode_implicit_attribute";
         using implicit_attribute_type = double;
         ImplicitCrossSection();

--- a/include/geode/geosciences/implicit/representation/core/implicit_cross_section.h
+++ b/include/geode/geosciences/implicit/representation/core/implicit_cross_section.h
@@ -83,7 +83,7 @@ namespace geode
          * Return the implicit value of the point, calculated in the polygon
          * containing the given point in the given surface, if there is any.
          */
-        absl::optional< double > implicit_value(
+        std::optional< double > implicit_value(
             const Surface2D& surface, const Point2D& point ) const;
 
         /*!
@@ -98,18 +98,18 @@ namespace geode
          * Returns the surface polygon containing the given point, if there is
          * any.
          */
-        absl::optional< index_t > containing_polygon(
+        std::optional< index_t > containing_polygon(
             const Surface2D& surface, const Point2D& point ) const;
 
         const HorizonsStack2D& horizons_stack() const;
 
-        absl::optional< implicit_attribute_type > horizon_implicit_value(
+        std::optional< implicit_attribute_type > horizon_implicit_value(
             const Horizon2D& horizon ) const;
 
         bool implicit_value_is_above_horizon(
             double implicit_function_value, const Horizon2D& horizon ) const;
 
-        absl::optional< uuid > containing_stratigraphic_unit(
+        std::optional< uuid > containing_stratigraphic_unit(
             implicit_attribute_type implicit_function_value ) const;
 
     public:

--- a/include/geode/geosciences/implicit/representation/core/implicit_cross_section.h
+++ b/include/geode/geosciences/implicit/representation/core/implicit_cross_section.h
@@ -65,12 +65,12 @@ namespace geode
 
         ImplicitCrossSection clone() const;
 
-        static constexpr absl::string_view native_extension_static()
+        static constexpr std::string_view native_extension_static()
         {
             return "og_ixsctn";
         }
 
-        absl::string_view native_extension() const
+        std::string_view native_extension() const
         {
             return native_extension_static();
         }

--- a/include/geode/geosciences/implicit/representation/core/implicit_structural_model.h
+++ b/include/geode/geosciences/implicit/representation/core/implicit_structural_model.h
@@ -84,7 +84,7 @@ namespace geode
          * Return the implicit value on the point, computed in the polyhedron
          * containing the given point in the given block, if there is any.
          */
-        absl::optional< implicit_attribute_type > implicit_value(
+        std::optional< implicit_attribute_type > implicit_value(
             const Block3D& block, const Point3D& point ) const;
 
         /*!
@@ -99,18 +99,18 @@ namespace geode
          * Returns the block polyhedron containing the given point, if there is
          * any.
          */
-        absl::optional< index_t > containing_polyhedron(
+        std::optional< index_t > containing_polyhedron(
             const Block3D& block, const Point3D& point ) const;
 
         const HorizonsStack3D& horizons_stack() const;
 
-        absl::optional< implicit_attribute_type > horizon_implicit_value(
+        std::optional< implicit_attribute_type > horizon_implicit_value(
             const Horizon3D& horizon ) const;
 
         bool implicit_value_is_above_horizon(
             double implicit_function_value, const Horizon3D& horizon ) const;
 
-        absl::optional< uuid > containing_stratigraphic_unit(
+        std::optional< uuid > containing_stratigraphic_unit(
             implicit_attribute_type implicit_function_value ) const;
 
     public:

--- a/include/geode/geosciences/implicit/representation/core/implicit_structural_model.h
+++ b/include/geode/geosciences/implicit/representation/core/implicit_structural_model.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <geode/basic/pimpl.h>
 
 #include <geode/geosciences/explicit/representation/core/structural_model.h>

--- a/include/geode/geosciences/implicit/representation/core/implicit_structural_model.h
+++ b/include/geode/geosciences/implicit/representation/core/implicit_structural_model.h
@@ -52,7 +52,7 @@ namespace geode
             ImplicitStructuralModelBuilder, ImplicitStructuralModelBuilderKey );
 
     public:
-        static constexpr auto implicit_attribute_name =
+        static constexpr auto IMPLICIT_ATTRIBUTE_NAME =
             "geode_implicit_attribute";
         using implicit_attribute_type = double;
         ImplicitStructuralModel();

--- a/include/geode/geosciences/implicit/representation/core/implicit_structural_model.h
+++ b/include/geode/geosciences/implicit/representation/core/implicit_structural_model.h
@@ -66,12 +66,12 @@ namespace geode
 
         ImplicitStructuralModel clone() const;
 
-        static constexpr absl::string_view native_extension_static()
+        static constexpr std::string_view native_extension_static()
         {
             return "og_istrm";
         }
 
-        absl::string_view native_extension() const
+        std::string_view native_extension() const
         {
             return native_extension_static();
         }

--- a/include/geode/geosciences/implicit/representation/core/stratigraphic_model.h
+++ b/include/geode/geosciences/implicit/representation/core/stratigraphic_model.h
@@ -92,7 +92,7 @@ namespace geode
          * polyhedron containing the given point in the given block, if there is
          * any.
          */
-        absl::optional< StratigraphicPoint3D > stratigraphic_coordinates(
+        std::optional< StratigraphicPoint3D > stratigraphic_coordinates(
             const Block3D& block, const Point3D& geometric_point ) const;
 
         /*!
@@ -109,7 +109,7 @@ namespace geode
          * coordinates in the stratigraphic space in the given block, if there
          * is any.
          */
-        absl::optional< Point3D > geometric_coordinates( const Block3D& block,
+        std::optional< Point3D > geometric_coordinates( const Block3D& block,
             const StratigraphicPoint3D& stratigraphic_point ) const;
 
         /*!
@@ -124,7 +124,7 @@ namespace geode
          * Returns the block polyhedron containing the given stratigraphic
          * point, if there is any.
          */
-        absl::optional< index_t > stratigraphic_containing_polyhedron(
+        std::optional< index_t > stratigraphic_containing_polyhedron(
             const Block3D& block,
             const StratigraphicPoint3D& stratigraphic_point ) const;
 

--- a/include/geode/geosciences/implicit/representation/core/stratigraphic_model.h
+++ b/include/geode/geosciences/implicit/representation/core/stratigraphic_model.h
@@ -70,12 +70,12 @@ namespace geode
 
         StratigraphicModel clone() const;
 
-        static constexpr absl::string_view native_extension_static()
+        static constexpr std::string_view native_extension_static()
         {
             return "og_stgm";
         }
 
-        absl::string_view native_extension() const
+        std::string_view native_extension() const
         {
             return native_extension_static();
         }

--- a/include/geode/geosciences/implicit/representation/core/stratigraphic_model.h
+++ b/include/geode/geosciences/implicit/representation/core/stratigraphic_model.h
@@ -52,10 +52,10 @@ namespace geode
         PASSKEY( StratigraphicModelBuilder, StratigraphicModelBuilderKey );
 
     public:
-        static constexpr auto stratigraphic_location_attribute_name =
+        static constexpr auto STRATIGRAPHIC_LOCATION_ATTRIBUTE_NAME =
             "geode_stratigraphic_location";
         static constexpr auto
-            stratigraphic_surface_polyhedron_facet_attribute_name =
+            STRATIGRAPHIC_SURFACE_POLYHEDRON_FACET_ATTRIBUTE_NAME =
                 "geode_associated_block_polyhedron_facet";
         using stratigraphic_location_type = Point2D;
         StratigraphicModel();

--- a/include/geode/geosciences/implicit/representation/core/stratigraphic_section.h
+++ b/include/geode/geosciences/implicit/representation/core/stratigraphic_section.h
@@ -55,9 +55,9 @@ namespace geode
         PASSKEY( StratigraphicSectionBuilder, StratigraphicSectionBuilderKey );
 
     public:
-        static constexpr auto stratigraphic_location_attribute_name =
+        static constexpr auto STRATIGRAPHIC_LOCATION_ATTRIBUTE_NAME =
             "geode_stratigraphic_location";
-        static constexpr auto stratigraphic_line_polygon_edge_attribute_name =
+        static constexpr auto STRATIGRAPHIC_LINE_POLYGON_EDGE_ATTRIBUTE_NAME =
             "geode_associated_surface_polygon_edge";
 
         using stratigraphic_location_type = Point1D;

--- a/include/geode/geosciences/implicit/representation/core/stratigraphic_section.h
+++ b/include/geode/geosciences/implicit/representation/core/stratigraphic_section.h
@@ -74,12 +74,12 @@ namespace geode
 
         StratigraphicSection clone() const;
 
-        static constexpr absl::string_view native_extension_static()
+        static constexpr std::string_view native_extension_static()
         {
             return "og_stgs";
         }
 
-        absl::string_view native_extension() const
+        std::string_view native_extension() const
         {
             return native_extension_static();
         }

--- a/include/geode/geosciences/implicit/representation/core/stratigraphic_section.h
+++ b/include/geode/geosciences/implicit/representation/core/stratigraphic_section.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <geode/basic/pimpl.h>
 
 #include <geode/geosciences/implicit/common.h>

--- a/include/geode/geosciences/implicit/representation/core/stratigraphic_section.h
+++ b/include/geode/geosciences/implicit/representation/core/stratigraphic_section.h
@@ -94,7 +94,7 @@ namespace geode
          * in the polygon containing the given point in the given surface, if
          * there is any.
          */
-        absl::optional< StratigraphicPoint2D > stratigraphic_coordinates(
+        std::optional< StratigraphicPoint2D > stratigraphic_coordinates(
             const Surface2D& surface, const Point2D& geometric_point ) const;
 
         /*!
@@ -112,7 +112,7 @@ namespace geode
          * coordinates in the stratigraphic space in the given surface, if there
          * is any.
          */
-        absl::optional< Point2D > geometric_coordinates(
+        std::optional< Point2D > geometric_coordinates(
             const Surface2D& surface,
             const StratigraphicPoint2D& stratigraphic_point ) const;
 
@@ -129,7 +129,7 @@ namespace geode
          * Returns a surface polygon containing the given stratigraphic point,
          * if there is any.
          */
-        absl::optional< index_t > stratigraphic_containing_polygon(
+        std::optional< index_t > stratigraphic_containing_polygon(
             const Surface2D& surface,
             const StratigraphicPoint2D& stratigraphic_point ) const;
 

--- a/include/geode/geosciences/implicit/representation/io/geode/geode_horizons_stack_input.h
+++ b/include/geode/geosciences/implicit/representation/io/geode/geode_horizons_stack_input.h
@@ -33,19 +33,19 @@ namespace geode
         : public HorizonsStackInput< dimension >
     {
     public:
-        OpenGeodeHorizonsStackInput( absl::string_view filename )
+        OpenGeodeHorizonsStackInput( std::string_view filename )
             : HorizonsStackInput< dimension >( filename )
         {
         }
 
-        static absl::string_view extension()
+        static std::string_view extension()
         {
             return HorizonsStack< dimension >::native_extension_static();
         }
 
         void load_horizons_stack_files(
             HorizonsStack< dimension >& horizons_stack,
-            absl::string_view directory );
+            std::string_view directory );
 
         HorizonsStack< dimension > read() final;
     };

--- a/include/geode/geosciences/implicit/representation/io/geode/geode_horizons_stack_output.h
+++ b/include/geode/geosciences/implicit/representation/io/geode/geode_horizons_stack_output.h
@@ -43,12 +43,12 @@ namespace geode
         : public HorizonsStackOutput< dimension >
     {
     public:
-        OpenGeodeHorizonsStackOutput( absl::string_view filename )
+        OpenGeodeHorizonsStackOutput( std::string_view filename )
             : HorizonsStackOutput< dimension >( filename )
         {
         }
 
-        static absl::string_view extension()
+        static std::string_view extension()
         {
             return HorizonsStack< dimension >::native_extension_static();
         }
@@ -64,7 +64,7 @@ namespace geode
 
         void save_horizons_stack_files(
             const HorizonsStack< dimension >& horizons_stack,
-            absl::string_view directory ) const
+            std::string_view directory ) const
         {
             async::parallel_invoke(
                 [&directory, &horizons_stack] {

--- a/include/geode/geosciences/implicit/representation/io/geode/geode_horizons_stack_output.h
+++ b/include/geode/geosciences/implicit/representation/io/geode/geode_horizons_stack_output.h
@@ -23,12 +23,11 @@
 
 #pragma once
 
+#include <filesystem>
 #include <string>
 #include <vector>
 
 #include <async++.h>
-
-#include <ghc/filesystem.hpp>
 
 #include <geode/basic/uuid.h>
 #include <geode/basic/zip_file.h>
@@ -56,7 +55,7 @@ namespace geode
         void archive_horizons_stack_files( const ZipFile& zip_writer ) const
         {
             for( const auto& file :
-                ghc::filesystem::directory_iterator( zip_writer.directory() ) )
+                std::filesystem::directory_iterator( zip_writer.directory() ) )
             {
                 zip_writer.archive_file( file.path().string() );
             }

--- a/include/geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_input.h
+++ b/include/geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_input.h
@@ -32,18 +32,18 @@ namespace geode
         final : public ImplicitCrossSectionInput
     {
     public:
-        OpenGeodeImplicitCrossSectionInput( absl::string_view filename )
+        OpenGeodeImplicitCrossSectionInput( std::string_view filename )
             : ImplicitCrossSectionInput( filename )
         {
         }
 
-        static absl::string_view extension()
+        static std::string_view extension()
         {
             return ImplicitCrossSection::native_extension_static();
         }
 
         void load_implicit_cross_section_files(
-            ImplicitCrossSection& section, absl::string_view directory );
+            ImplicitCrossSection& section, std::string_view directory );
 
         ImplicitCrossSection read() final;
     };

--- a/include/geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_output.h
+++ b/include/geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_output.h
@@ -40,12 +40,12 @@ namespace geode
         final : public ImplicitCrossSectionOutput
     {
     public:
-        OpenGeodeImplicitCrossSectionOutput( absl::string_view filename )
+        OpenGeodeImplicitCrossSectionOutput( std::string_view filename )
             : ImplicitCrossSectionOutput( filename )
         {
         }
 
-        static absl::string_view extension()
+        static std::string_view extension()
         {
             return ImplicitCrossSection::native_extension_static();
         }
@@ -54,7 +54,7 @@ namespace geode
 
         void save_implicit_section_files(
             const ImplicitCrossSection& implicit_section,
-            absl::string_view directory ) const;
+            std::string_view directory ) const;
 
         std::vector< std::string > write(
             const ImplicitCrossSection& implicit_section ) const final;

--- a/include/geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_input.h
+++ b/include/geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_input.h
@@ -33,18 +33,18 @@ namespace geode
         : public ImplicitStructuralModelInput
     {
     public:
-        OpenGeodeImplicitStructuralModelInput( absl::string_view filename )
+        OpenGeodeImplicitStructuralModelInput( std::string_view filename )
             : ImplicitStructuralModelInput( filename )
         {
         }
 
-        static absl::string_view extension()
+        static std::string_view extension()
         {
             return ImplicitStructuralModel::native_extension_static();
         }
 
         void load_implicit_structural_model_files(
-            ImplicitStructuralModel& model, absl::string_view directory );
+            ImplicitStructuralModel& model, std::string_view directory );
 
         ImplicitStructuralModel read() final;
     };

--- a/include/geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_output.h
+++ b/include/geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_output.h
@@ -41,12 +41,12 @@ namespace geode
         : public ImplicitStructuralModelOutput
     {
     public:
-        OpenGeodeImplicitStructuralModelOutput( absl::string_view filename )
+        OpenGeodeImplicitStructuralModelOutput( std::string_view filename )
             : ImplicitStructuralModelOutput( filename )
         {
         }
 
-        static absl::string_view extension()
+        static std::string_view extension()
         {
             return ImplicitStructuralModel::native_extension_static();
         }
@@ -55,7 +55,7 @@ namespace geode
 
         void save_implicit_model_files(
             const ImplicitStructuralModel& implicit_model,
-            absl::string_view directory ) const;
+            std::string_view directory ) const;
 
         std::vector< std::string > write(
             const ImplicitStructuralModel& implicit_model ) const final;

--- a/include/geode/geosciences/implicit/representation/io/horizons_stack_input.h
+++ b/include/geode/geosciences/implicit/representation/io/horizons_stack_input.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <absl/strings/string_view.h>
+#include <string_view>
 
 #include <geode/basic/factory.h>
 #include <geode/basic/input.h>
@@ -45,8 +45,7 @@ namespace geode
      * @return Loaded HorizonsStack.
      */
     template < index_t dimension >
-    HorizonsStack< dimension > load_horizons_stack(
-        absl::string_view filename );
+    HorizonsStack< dimension > load_horizons_stack( std::string_view filename );
 
     template < index_t dimension >
     class HorizonsStackInput : public Input< HorizonsStack< dimension > >
@@ -57,7 +56,7 @@ namespace geode
         using typename Base::MissingFiles;
 
     protected:
-        explicit HorizonsStackInput( absl::string_view filename )
+        explicit HorizonsStackInput( std::string_view filename )
             : Base{ filename }
         {
         }
@@ -65,14 +64,14 @@ namespace geode
 
     template < index_t dimension >
     typename HorizonsStackInput< dimension >::MissingFiles
-        check_horizons_stack_missing_files( absl::string_view filename );
+        check_horizons_stack_missing_files( std::string_view filename );
 
     template < index_t dimension >
-    bool is_horizons_stack_loadable( absl::string_view filename );
+    bool is_horizons_stack_loadable( std::string_view filename );
 
     template < index_t dimension >
     using HorizonsStackInputFactory = Factory< std::string,
         HorizonsStackInput< dimension >,
-        absl::string_view >;
+        std::string_view >;
     ALIAS_2D_AND_3D( HorizonsStackInputFactory );
 } // namespace geode

--- a/include/geode/geosciences/implicit/representation/io/horizons_stack_output.h
+++ b/include/geode/geosciences/implicit/representation/io/horizons_stack_output.h
@@ -24,9 +24,8 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/factory.h>
 #include <geode/basic/output.h>
@@ -50,13 +49,13 @@ namespace geode
     template < index_t dimension >
     std::vector< std::string > save_horizons_stack(
         const HorizonsStack< dimension >& horizons_stack,
-        absl::string_view filename );
+        std::string_view filename );
 
     template < index_t dimension >
     class HorizonsStackOutput : public Output< HorizonsStack< dimension > >
     {
     protected:
-        HorizonsStackOutput( absl::string_view filename )
+        HorizonsStackOutput( std::string_view filename )
             : Output< HorizonsStack< dimension > >{ filename }
         {
         }
@@ -66,6 +65,6 @@ namespace geode
     template < index_t dimension >
     using HorizonsStackOutputFactory = Factory< std::string,
         HorizonsStackOutput< dimension >,
-        absl::string_view >;
+        std::string_view >;
     ALIAS_2D_AND_3D( HorizonsStackOutputFactory );
 } // namespace geode

--- a/include/geode/geosciences/implicit/representation/io/implicit_cross_section_input.h
+++ b/include/geode/geosciences/implicit/representation/io/implicit_cross_section_input.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <absl/strings/string_view.h>
+#include <string_view>
 
 #include <geode/basic/factory.h>
 #include <geode/basic/input.h>
@@ -43,7 +43,7 @@ namespace geode
      * @param[in] filename Path to the file to load.
      */
     ImplicitCrossSection opengeode_geosciences_implicit_api
-        load_implicit_cross_section( absl::string_view filename );
+        load_implicit_cross_section( std::string_view filename );
 
     class ImplicitCrossSectionInput : public Input< ImplicitCrossSection >
     {
@@ -53,19 +53,18 @@ namespace geode
         using typename Base::MissingFiles;
 
     protected:
-        explicit ImplicitCrossSectionInput( absl::string_view filename )
+        explicit ImplicitCrossSectionInput( std::string_view filename )
             : Base{ filename }
         {
         }
     };
 
     ImplicitCrossSectionInput::MissingFiles opengeode_geosciences_implicit_api
-        check_implicit_cross_section_missing_files(
-            absl::string_view filename );
+        check_implicit_cross_section_missing_files( std::string_view filename );
 
     bool opengeode_geosciences_implicit_api is_implicit_cross_section_loadable(
-        absl::string_view filename );
+        std::string_view filename );
 
     using ImplicitCrossSectionInputFactory =
-        Factory< std::string, ImplicitCrossSectionInput, absl::string_view >;
+        Factory< std::string, ImplicitCrossSectionInput, std::string_view >;
 } // namespace geode

--- a/include/geode/geosciences/implicit/representation/io/implicit_cross_section_output.h
+++ b/include/geode/geosciences/implicit/representation/io/implicit_cross_section_output.h
@@ -24,9 +24,8 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/factory.h>
 #include <geode/basic/output.h>
@@ -49,7 +48,7 @@ namespace geode
      */
     std::vector< std::string > opengeode_geosciences_implicit_api
         save_implicit_cross_section( const ImplicitCrossSection& implicit_model,
-            absl::string_view filename );
+            std::string_view filename );
 
     class ImplicitCrossSectionOutput : public Output< ImplicitCrossSection >
     {
@@ -57,15 +56,15 @@ namespace geode
         virtual ~ImplicitCrossSectionOutput() = default;
 
     protected:
-        ImplicitCrossSectionOutput( absl::string_view filename )
+        ImplicitCrossSectionOutput( std::string_view filename )
             : Output< ImplicitCrossSection >{ filename }
         {
         }
     };
 
     bool opengeode_geosciences_implicit_api is_implicit_cross_section_saveable(
-        const ImplicitCrossSection& section, absl::string_view filename );
+        const ImplicitCrossSection& section, std::string_view filename );
 
     using ImplicitCrossSectionOutputFactory =
-        Factory< std::string, ImplicitCrossSectionOutput, absl::string_view >;
+        Factory< std::string, ImplicitCrossSectionOutput, std::string_view >;
 } // namespace geode

--- a/include/geode/geosciences/implicit/representation/io/implicit_structural_model_input.h
+++ b/include/geode/geosciences/implicit/representation/io/implicit_structural_model_input.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <absl/strings/string_view.h>
+#include <string_view>
 
 #include <geode/basic/factory.h>
 #include <geode/basic/input.h>
@@ -43,7 +43,7 @@ namespace geode
      * @param[in] filename Path to the file to load.
      */
     ImplicitStructuralModel opengeode_geosciences_implicit_api
-        load_implicit_structural_model( absl::string_view filename );
+        load_implicit_structural_model( std::string_view filename );
 
     class ImplicitStructuralModelInput : public Input< ImplicitStructuralModel >
     {
@@ -53,7 +53,7 @@ namespace geode
         using typename Base::MissingFiles;
 
     protected:
-        explicit ImplicitStructuralModelInput( absl::string_view filename )
+        explicit ImplicitStructuralModelInput( std::string_view filename )
             : Base{ filename }
         {
         }
@@ -62,11 +62,11 @@ namespace geode
     ImplicitStructuralModelInput::MissingFiles
         opengeode_geosciences_implicit_api
         check_implicit_structural_model_missing_files(
-            absl::string_view filename );
+            std::string_view filename );
 
     bool opengeode_geosciences_implicit_api
-        is_implicit_structural_model_loadable( absl::string_view filename );
+        is_implicit_structural_model_loadable( std::string_view filename );
 
     using ImplicitStructuralModelInputFactory =
-        Factory< std::string, ImplicitStructuralModelInput, absl::string_view >;
+        Factory< std::string, ImplicitStructuralModelInput, std::string_view >;
 } // namespace geode

--- a/include/geode/geosciences/implicit/representation/io/implicit_structural_model_output.h
+++ b/include/geode/geosciences/implicit/representation/io/implicit_structural_model_output.h
@@ -24,9 +24,8 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/factory.h>
 #include <geode/basic/output.h>
@@ -50,7 +49,7 @@ namespace geode
     std::vector< std::string >
         opengeode_geosciences_implicit_api save_implicit_structural_model(
             const ImplicitStructuralModel& implicit_model,
-            absl::string_view filename );
+            std::string_view filename );
 
     class opengeode_geosciences_implicit_api ImplicitStructuralModelOutput
         : public Output< ImplicitStructuralModel >
@@ -59,7 +58,7 @@ namespace geode
         virtual ~ImplicitStructuralModelOutput() = default;
 
     protected:
-        ImplicitStructuralModelOutput( absl::string_view filename )
+        ImplicitStructuralModelOutput( std::string_view filename )
             : Output< ImplicitStructuralModel >{ filename }
         {
         }
@@ -68,9 +67,8 @@ namespace geode
     bool opengeode_geosciences_implicit_api
         is_implicit_structural_model_saveable(
             const ImplicitStructuralModel& implicit_model,
-            absl::string_view filename );
+            std::string_view filename );
 
-    using ImplicitStructuralModelOutputFactory = Factory< std::string,
-        ImplicitStructuralModelOutput,
-        absl::string_view >;
+    using ImplicitStructuralModelOutputFactory =
+        Factory< std::string, ImplicitStructuralModelOutput, std::string_view >;
 } // namespace geode

--- a/include/geode/geosciences/implicit/representation/io/stratigraphic_model_input.h
+++ b/include/geode/geosciences/implicit/representation/io/stratigraphic_model_input.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <absl/strings/string_view.h>
+#include <string_view>
 
 #include <geode/basic/factory.h>
 #include <geode/basic/input.h>
@@ -43,7 +43,7 @@ namespace geode
      * @param[in] filename Path to the file to load.
      */
     StratigraphicModel opengeode_geosciences_implicit_api
-        load_stratigraphic_model( absl::string_view filename );
+        load_stratigraphic_model( std::string_view filename );
 
     class StratigraphicModelInput : public Input< StratigraphicModel >
     {
@@ -53,18 +53,18 @@ namespace geode
         using typename Base::MissingFiles;
 
     protected:
-        explicit StratigraphicModelInput( absl::string_view filename )
+        explicit StratigraphicModelInput( std::string_view filename )
             : Base{ filename }
         {
         }
     };
 
     StratigraphicModelInput::MissingFiles opengeode_geosciences_implicit_api
-        check_stratigraphic_model_missing_files( absl::string_view filename );
+        check_stratigraphic_model_missing_files( std::string_view filename );
 
     bool opengeode_geosciences_implicit_api is_stratigraphic_model_loadable(
-        absl::string_view filename );
+        std::string_view filename );
 
     using StratigraphicModelInputFactory =
-        Factory< std::string, StratigraphicModelInput, absl::string_view >;
+        Factory< std::string, StratigraphicModelInput, std::string_view >;
 } // namespace geode

--- a/include/geode/geosciences/implicit/representation/io/stratigraphic_model_output.h
+++ b/include/geode/geosciences/implicit/representation/io/stratigraphic_model_output.h
@@ -24,9 +24,8 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/factory.h>
 #include <geode/basic/output.h>
@@ -49,7 +48,7 @@ namespace geode
      */
     std::vector< std::string > opengeode_geosciences_implicit_api
         save_stratigraphic_model( const StratigraphicModel& stratigraphic_model,
-            absl::string_view filename );
+            std::string_view filename );
 
     class opengeode_geosciences_implicit_api StratigraphicModelOutput
         : public Output< StratigraphicModel >
@@ -58,7 +57,7 @@ namespace geode
         virtual ~StratigraphicModelOutput() = default;
 
     protected:
-        StratigraphicModelOutput( absl::string_view filename )
+        StratigraphicModelOutput( std::string_view filename )
             : Output< StratigraphicModel >{ filename }
         {
         }
@@ -66,8 +65,8 @@ namespace geode
 
     bool opengeode_geosciences_implicit_api is_stratigraphic_model_saveable(
         const StratigraphicModel& stratigraphic_model,
-        absl::string_view filename );
+        std::string_view filename );
 
     using StratigraphicModelOutputFactory =
-        Factory< std::string, StratigraphicModelOutput, absl::string_view >;
+        Factory< std::string, StratigraphicModelOutput, std::string_view >;
 } // namespace geode

--- a/include/geode/geosciences/implicit/representation/io/stratigraphic_section_input.h
+++ b/include/geode/geosciences/implicit/representation/io/stratigraphic_section_input.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <absl/strings/string_view.h>
+#include <string_view>
 
 #include <geode/basic/factory.h>
 #include <geode/basic/input.h>
@@ -43,7 +43,7 @@ namespace geode
      * @param[in] filename Path to the file to load.
      */
     StratigraphicSection opengeode_geosciences_implicit_api
-        load_stratigraphic_section( absl::string_view filename );
+        load_stratigraphic_section( std::string_view filename );
 
     class StratigraphicSectionInput : public Input< StratigraphicSection >
     {
@@ -53,18 +53,18 @@ namespace geode
         using typename Base::MissingFiles;
 
     protected:
-        explicit StratigraphicSectionInput( absl::string_view filename )
+        explicit StratigraphicSectionInput( std::string_view filename )
             : Base{ filename }
         {
         }
     };
 
     StratigraphicSectionInput::MissingFiles opengeode_geosciences_implicit_api
-        check_stratigraphic_section_missing_files( absl::string_view filename );
+        check_stratigraphic_section_missing_files( std::string_view filename );
 
     bool opengeode_geosciences_implicit_api is_stratigraphic_section_loadable(
-        absl::string_view filename );
+        std::string_view filename );
 
     using StratigraphicSectionInputFactory =
-        Factory< std::string, StratigraphicSectionInput, absl::string_view >;
+        Factory< std::string, StratigraphicSectionInput, std::string_view >;
 } // namespace geode

--- a/include/geode/geosciences/implicit/representation/io/stratigraphic_section_output.h
+++ b/include/geode/geosciences/implicit/representation/io/stratigraphic_section_output.h
@@ -24,9 +24,8 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/factory.h>
 #include <geode/basic/output.h>
@@ -50,7 +49,7 @@ namespace geode
     std::vector< std::string >
         opengeode_geosciences_implicit_api save_stratigraphic_section(
             const StratigraphicSection& stratigraphic_section,
-            absl::string_view filename );
+            std::string_view filename );
 
     class StratigraphicSectionOutput : public Output< StratigraphicSection >
     {
@@ -58,7 +57,7 @@ namespace geode
         virtual ~StratigraphicSectionOutput() = default;
 
     protected:
-        StratigraphicSectionOutput( absl::string_view filename )
+        StratigraphicSectionOutput( std::string_view filename )
             : Output< StratigraphicSection >{ filename }
         {
         }
@@ -66,8 +65,8 @@ namespace geode
 
     bool opengeode_geosciences_implicit_api is_stratigraphic_section_saveable(
         const StratigraphicSection& stratigraphic_section,
-        absl::string_view filename );
+        std::string_view filename );
 
     using StratigraphicSectionOutputFactory =
-        Factory< std::string, StratigraphicSectionOutput, absl::string_view >;
+        Factory< std::string, StratigraphicSectionOutput, std::string_view >;
 } // namespace geode

--- a/src/geode/geosciences/explicit/geometry/geographic_coordinate_system.cpp
+++ b/src/geode/geosciences/explicit/geometry/geographic_coordinate_system.cpp
@@ -29,7 +29,7 @@
 #include <geode/basic/logger.h>
 #include <geode/basic/pimpl_impl.h>
 
-#include <geode/mesh/core/private/points_impl.h>
+#include <geode/mesh/core/internal/points_impl.h>
 
 namespace geode
 {

--- a/src/geode/geosciences/explicit/geometry/geographic_coordinate_system_helper.cpp
+++ b/src/geode/geosciences/explicit/geometry/geographic_coordinate_system_helper.cpp
@@ -51,7 +51,7 @@ namespace
     template < typename Mesh >
     void convert_coordinate_reference_system( const Mesh& mesh,
         typename Mesh::Builder& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename geode::GeographicCoordinateSystem< Mesh::dim >::Info info )
     {
         using GeoCRS = typename geode::GeographicCoordinateSystem< Mesh::dim >;
@@ -86,7 +86,7 @@ namespace
     void convert_components_coordinate_reference_system(
         const typename geode::GeographicCoordinateSystem< dimension >::Info&
             info,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         Range range,
         GetMeshBuilder get_mesh_builder )
     {
@@ -103,7 +103,7 @@ namespace
     void convert_attribute_to_geographic_coordinate_reference_system(
         const Mesh& mesh,
         typename Mesh::Builder& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename geode::GeographicCoordinateSystem< Mesh::dim >::Info info )
     {
         const auto& crs_manager =
@@ -131,7 +131,7 @@ namespace
     void convert_components_attribute_to_geographic_coordinate_reference_system(
         const typename geode::GeographicCoordinateSystem< dimension >::Info&
             info,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         Range range,
         GetMeshBuilder get_mesh_builder )
     {
@@ -151,7 +151,7 @@ namespace geode
     void assign_edged_curve_geographic_coordinate_system_info(
         const EdgedCurve< dimension >& mesh,
         EdgedCurveBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info )
     {
         convert_attribute_to_geographic_coordinate_reference_system(
@@ -162,7 +162,7 @@ namespace geode
     void assign_point_set_geographic_coordinate_system_info(
         const PointSet< dimension >& mesh,
         PointSetBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info )
     {
         convert_attribute_to_geographic_coordinate_reference_system(
@@ -173,7 +173,7 @@ namespace geode
     void assign_solid_mesh_geographic_coordinate_system_info(
         const SolidMesh< dimension >& mesh,
         SolidMeshBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info )
     {
         convert_attribute_to_geographic_coordinate_reference_system(
@@ -184,7 +184,7 @@ namespace geode
     void assign_surface_mesh_geographic_coordinate_system_info(
         const SurfaceMesh< dimension >& mesh,
         SurfaceMeshBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info )
     {
         convert_attribute_to_geographic_coordinate_reference_system(
@@ -193,7 +193,7 @@ namespace geode
 
     void assign_brep_geographic_coordinate_system_info( const BRep& brep,
         BRepBuilder& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         const GeographicCoordinateSystem3D::Info& info )
     {
         convert_components_attribute_to_geographic_coordinate_reference_system<
@@ -217,7 +217,7 @@ namespace geode
     void assign_section_geographic_coordinate_system_info(
         const Section& section,
         SectionBuilder& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         const GeographicCoordinateSystem2D::Info& info )
     {
         convert_components_attribute_to_geographic_coordinate_reference_system<
@@ -240,7 +240,7 @@ namespace geode
     void convert_edged_curve_coordinate_reference_system(
         const EdgedCurve< dimension >& mesh,
         EdgedCurveBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info )
     {
         convert_coordinate_reference_system(
@@ -251,7 +251,7 @@ namespace geode
     void convert_point_set_coordinate_reference_system(
         const PointSet< dimension >& mesh,
         PointSetBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info )
     {
         convert_coordinate_reference_system(
@@ -262,7 +262,7 @@ namespace geode
     void convert_solid_mesh_coordinate_reference_system(
         const SolidMesh< dimension >& mesh,
         SolidMeshBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info )
     {
         convert_coordinate_reference_system(
@@ -273,7 +273,7 @@ namespace geode
     void convert_surface_mesh_coordinate_reference_system(
         const SurfaceMesh< dimension >& mesh,
         SurfaceMeshBuilder< dimension >& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         typename GeographicCoordinateSystem< dimension >::Info info )
     {
         convert_coordinate_reference_system(
@@ -282,7 +282,7 @@ namespace geode
 
     void convert_brep_coordinate_reference_system( const BRep& brep,
         BRepBuilder& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         const GeographicCoordinateSystem3D::Info& info )
     {
         convert_components_coordinate_reference_system< 3 >(
@@ -305,7 +305,7 @@ namespace geode
 
     void convert_section_coordinate_reference_system( const Section& section,
         SectionBuilder& builder,
-        absl::string_view crs_name,
+        std::string_view crs_name,
         const GeographicCoordinateSystem2D::Info& info )
     {
         convert_components_coordinate_reference_system< 2 >(
@@ -326,80 +326,80 @@ namespace geode
         assign_edged_curve_geographic_coordinate_system_info(
             const EdgedCurve< 2 >&,
             EdgedCurveBuilder< 2 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 2 >::Info );
     template void opengeode_geosciences_explicit_api
         assign_point_set_geographic_coordinate_system_info(
             const PointSet< 2 >&,
             PointSetBuilder< 2 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 2 >::Info );
     template void opengeode_geosciences_explicit_api
         assign_surface_mesh_geographic_coordinate_system_info(
             const SurfaceMesh< 2 >&,
             SurfaceMeshBuilder< 2 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 2 >::Info );
     template void opengeode_geosciences_explicit_api
         convert_edged_curve_coordinate_reference_system( const EdgedCurve< 2 >&,
             EdgedCurveBuilder< 2 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 2 >::Info );
     template void opengeode_geosciences_explicit_api
         convert_point_set_coordinate_reference_system( const PointSet< 2 >&,
             PointSetBuilder< 2 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 2 >::Info );
     template void opengeode_geosciences_explicit_api
         convert_surface_mesh_coordinate_reference_system(
             const SurfaceMesh< 2 >&,
             SurfaceMeshBuilder< 2 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 2 >::Info );
 
     template void opengeode_geosciences_explicit_api
         assign_edged_curve_geographic_coordinate_system_info(
             const EdgedCurve< 3 >&,
             EdgedCurveBuilder< 3 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 3 >::Info );
     template void opengeode_geosciences_explicit_api
         assign_point_set_geographic_coordinate_system_info(
             const PointSet< 3 >&,
             PointSetBuilder< 3 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 3 >::Info );
     template void opengeode_geosciences_explicit_api
         assign_solid_mesh_geographic_coordinate_system_info(
             const SolidMesh< 3 >&,
             SolidMeshBuilder< 3 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 3 >::Info );
     template void opengeode_geosciences_explicit_api
         assign_surface_mesh_geographic_coordinate_system_info(
             const SurfaceMesh< 3 >&,
             SurfaceMeshBuilder< 3 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 3 >::Info );
     template void opengeode_geosciences_explicit_api
         convert_edged_curve_coordinate_reference_system( const EdgedCurve< 3 >&,
             EdgedCurveBuilder< 3 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 3 >::Info );
     template void opengeode_geosciences_explicit_api
         convert_point_set_coordinate_reference_system( const PointSet< 3 >&,
             PointSetBuilder< 3 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 3 >::Info );
     template void opengeode_geosciences_explicit_api
         convert_solid_mesh_coordinate_reference_system( const SolidMesh< 3 >&,
             SolidMeshBuilder< 3 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 3 >::Info );
     template void opengeode_geosciences_explicit_api
         convert_surface_mesh_coordinate_reference_system(
             const SurfaceMesh< 3 >&,
             SurfaceMeshBuilder< 3 >&,
-            absl::string_view,
+            std::string_view,
             typename GeographicCoordinateSystem< 3 >::Info );
 } // namespace geode

--- a/src/geode/geosciences/explicit/mixin/builder/fault_blocks_builder.cpp
+++ b/src/geode/geosciences/explicit/mixin/builder/fault_blocks_builder.cpp
@@ -50,14 +50,14 @@ namespace geode
 
     template < index_t dimension >
     void FaultBlocksBuilder< dimension >::load_fault_blocks(
-        absl::string_view directory )
+        std::string_view directory )
     {
         return fault_blocks_.load_fault_blocks( directory );
     }
 
     template < index_t dimension >
     void FaultBlocksBuilder< dimension >::set_fault_block_name(
-        const uuid& id, absl::string_view name )
+        const uuid& id, std::string_view name )
     {
         fault_blocks_.modifiable_fault_block( id ).set_fault_block_name(
             name, typename FaultBlock< dimension >::FaultBlocksBuilderKey{} );

--- a/src/geode/geosciences/explicit/mixin/builder/faults_builder.cpp
+++ b/src/geode/geosciences/explicit/mixin/builder/faults_builder.cpp
@@ -62,7 +62,7 @@ namespace geode
     }
 
     template < index_t dimension >
-    void FaultsBuilder< dimension >::load_faults( absl::string_view directory )
+    void FaultsBuilder< dimension >::load_faults( std::string_view directory )
     {
         return faults_.load_faults( directory );
     }
@@ -77,7 +77,7 @@ namespace geode
 
     template < index_t dimension >
     void FaultsBuilder< dimension >::set_fault_name(
-        const uuid& id, absl::string_view name )
+        const uuid& id, std::string_view name )
     {
         faults_.modifiable_fault( id ).set_fault_name(
             name, typename Fault< dimension >::FaultsBuilderKey{} );

--- a/src/geode/geosciences/explicit/mixin/builder/horizons_builder.cpp
+++ b/src/geode/geosciences/explicit/mixin/builder/horizons_builder.cpp
@@ -63,7 +63,7 @@ namespace geode
 
     template < index_t dimension >
     void HorizonsBuilder< dimension >::load_horizons(
-        absl::string_view directory )
+        std::string_view directory )
     {
         return horizons_.load_horizons( directory );
     }
@@ -79,7 +79,7 @@ namespace geode
 
     template < index_t dimension >
     void HorizonsBuilder< dimension >::set_horizon_name(
-        const uuid& id, absl::string_view name )
+        const uuid& id, std::string_view name )
     {
         horizons_.modifiable_horizon( id ).set_horizon_name(
             name, typename Horizon< dimension >::HorizonsBuilderKey{} );

--- a/src/geode/geosciences/explicit/mixin/builder/stratigraphic_units_builder.cpp
+++ b/src/geode/geosciences/explicit/mixin/builder/stratigraphic_units_builder.cpp
@@ -51,14 +51,14 @@ namespace geode
 
     template < index_t dimension >
     void StratigraphicUnitsBuilder< dimension >::load_stratigraphic_units(
-        absl::string_view directory )
+        std::string_view directory )
     {
         return stratigraphic_units_.load_stratigraphic_units( directory );
     }
 
     template < index_t dimension >
     void StratigraphicUnitsBuilder< dimension >::set_stratigraphic_unit_name(
-        const uuid& id, absl::string_view name )
+        const uuid& id, std::string_view name )
     {
         stratigraphic_units_.modifiable_stratigraphic_unit( id )
             .set_stratigraphic_unit_name(

--- a/src/geode/geosciences/explicit/mixin/core/fault.cpp
+++ b/src/geode/geosciences/explicit/mixin/core/fault.cpp
@@ -52,7 +52,7 @@ namespace geode
         }
 
     private:
-        FAULT_TYPE fault_type_{ FAULT_TYPE::NO_TYPE };
+        FAULT_TYPE fault_type_{ FAULT_TYPE::no_type };
     };
 
     template < index_t dimension >
@@ -73,7 +73,7 @@ namespace geode
     template < index_t dimension >
     bool Fault< dimension >::has_type() const
     {
-        return type() != FAULT_TYPE::NO_TYPE;
+        return type() != FAULT_TYPE::no_type;
     }
 
     template < index_t dimension >

--- a/src/geode/geosciences/explicit/mixin/core/fault_blocks.cpp
+++ b/src/geode/geosciences/explicit/mixin/core/fault_blocks.cpp
@@ -80,14 +80,14 @@ namespace geode
 
     template < index_t dimension >
     void FaultBlocks< dimension >::save_fault_blocks(
-        absl::string_view directory ) const
+        std::string_view directory ) const
     {
         impl_->save_components( absl::StrCat( directory, "/fault_blocks" ) );
     }
 
     template < index_t dimension >
     void FaultBlocks< dimension >::load_fault_blocks(
-        absl::string_view directory )
+        std::string_view directory )
     {
         impl_->load_components( absl::StrCat( directory, "/fault_blocks" ) );
     }

--- a/src/geode/geosciences/explicit/mixin/core/faults.cpp
+++ b/src/geode/geosciences/explicit/mixin/core/faults.cpp
@@ -77,13 +77,13 @@ namespace geode
     }
 
     template < index_t dimension >
-    void Faults< dimension >::save_faults( absl::string_view directory ) const
+    void Faults< dimension >::save_faults( std::string_view directory ) const
     {
         impl_->save_components( absl::StrCat( directory, "/faults" ) );
     }
 
     template < index_t dimension >
-    void Faults< dimension >::load_faults( absl::string_view directory )
+    void Faults< dimension >::load_faults( std::string_view directory )
     {
         impl_->load_components( absl::StrCat( directory, "/faults" ) );
     }

--- a/src/geode/geosciences/explicit/mixin/core/horizon.cpp
+++ b/src/geode/geosciences/explicit/mixin/core/horizon.cpp
@@ -52,7 +52,7 @@ namespace geode
         }
 
     private:
-        HORIZON_TYPE horizon_type_{ HORIZON_TYPE::NO_TYPE };
+        HORIZON_TYPE horizon_type_{ HORIZON_TYPE::no_type };
     };
 
     template < index_t dimension >
@@ -73,7 +73,7 @@ namespace geode
     template < index_t dimension >
     bool Horizon< dimension >::has_type() const
     {
-        return type() != HORIZON_TYPE::NO_TYPE;
+        return type() != HORIZON_TYPE::no_type;
     }
 
     template < index_t dimension >

--- a/src/geode/geosciences/explicit/mixin/core/horizons.cpp
+++ b/src/geode/geosciences/explicit/mixin/core/horizons.cpp
@@ -80,13 +80,13 @@ namespace geode
 
     template < index_t dimension >
     void Horizons< dimension >::save_horizons(
-        absl::string_view directory ) const
+        std::string_view directory ) const
     {
         impl_->save_components( absl::StrCat( directory, "/horizons" ) );
     }
 
     template < index_t dimension >
-    void Horizons< dimension >::load_horizons( absl::string_view directory )
+    void Horizons< dimension >::load_horizons( std::string_view directory )
     {
         impl_->load_components( absl::StrCat( directory, "/horizons" ) );
     }

--- a/src/geode/geosciences/explicit/mixin/core/stratigraphic_units.cpp
+++ b/src/geode/geosciences/explicit/mixin/core/stratigraphic_units.cpp
@@ -84,7 +84,7 @@ namespace geode
 
     template < index_t dimension >
     void StratigraphicUnits< dimension >::save_stratigraphic_units(
-        absl::string_view directory ) const
+        std::string_view directory ) const
     {
         impl_->save_components(
             absl::StrCat( directory, "/stratigraphic_units" ) );
@@ -92,7 +92,7 @@ namespace geode
 
     template < index_t dimension >
     void StratigraphicUnits< dimension >::load_stratigraphic_units(
-        absl::string_view directory )
+        std::string_view directory )
     {
         impl_->load_components(
             absl::StrCat( directory, "/stratigraphic_units" ) );

--- a/src/geode/geosciences/explicit/representation/io/cross_section_input.cpp
+++ b/src/geode/geosciences/explicit/representation/io/cross_section_input.cpp
@@ -24,7 +24,7 @@
 #include <geode/geosciences/explicit/representation/io/cross_section_input.h>
 
 #include <absl/strings/str_cat.h>
-#include <absl/strings/string_view.h>
+#include <string_view>
 
 #include <geode/basic/detail/geode_input_impl.h>
 #include <geode/basic/io.h>
@@ -37,7 +37,7 @@
 
 namespace geode
 {
-    CrossSection load_cross_section( absl::string_view filename )
+    CrossSection load_cross_section( std::string_view filename )
     {
         constexpr auto TYPE = "CrossSection";
         try
@@ -77,7 +77,7 @@ namespace geode
     }
 
     typename CrossSectionInput::MissingFiles check_cross_section_missing_files(
-        absl::string_view filename )
+        std::string_view filename )
     {
         const auto input =
             detail::geode_object_input_reader< CrossSectionInputFactory >(
@@ -85,7 +85,7 @@ namespace geode
         return input->check_missing_files();
     }
 
-    bool is_cross_section_loadable( absl::string_view filename )
+    bool is_cross_section_loadable( std::string_view filename )
     {
         const auto input =
             detail::geode_object_input_reader< CrossSectionInputFactory >(

--- a/src/geode/geosciences/explicit/representation/io/cross_section_output.cpp
+++ b/src/geode/geosciences/explicit/representation/io/cross_section_output.cpp
@@ -24,9 +24,8 @@
 #include <geode/geosciences/explicit/representation/io/cross_section_output.h>
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/detail/geode_output_impl.h>
 #include <geode/basic/io.h>
@@ -39,7 +38,7 @@
 namespace geode
 {
     std::vector< std::string > save_cross_section(
-        const CrossSection& cross_section, absl::string_view filename )
+        const CrossSection& cross_section, std::string_view filename )
     {
         constexpr auto TYPE = "CrossSection";
         try
@@ -59,7 +58,7 @@ namespace geode
     }
 
     bool is_cross_section_saveable(
-        const CrossSection& cross_section, absl::string_view filename )
+        const CrossSection& cross_section, std::string_view filename )
     {
         const auto output =
             detail::geode_object_output_writer< CrossSectionOutputFactory >(

--- a/src/geode/geosciences/explicit/representation/io/geode/geode_cross_section_input.cpp
+++ b/src/geode/geosciences/explicit/representation/io/geode/geode_cross_section_input.cpp
@@ -45,13 +45,13 @@
 namespace geode
 {
     OpenGeodeCrossSectionInput::OpenGeodeCrossSectionInput(
-        absl::string_view filename )
+        std::string_view filename )
         : CrossSectionInput{ filename }
     {
     }
 
     void OpenGeodeCrossSectionInput::load_cross_section_files(
-        CrossSection& cross_section, absl::string_view directory )
+        CrossSection& cross_section, std::string_view directory )
     {
         CrossSectionBuilder builder{ cross_section };
         async::parallel_invoke(

--- a/src/geode/geosciences/explicit/representation/io/geode/geode_cross_section_output.cpp
+++ b/src/geode/geosciences/explicit/representation/io/geode/geode_cross_section_output.cpp
@@ -38,13 +38,13 @@
 namespace geode
 {
     OpenGeodeCrossSectionOutput::OpenGeodeCrossSectionOutput(
-        absl::string_view filename )
+        std::string_view filename )
         : CrossSectionOutput( filename )
     {
     }
 
     void OpenGeodeCrossSectionOutput::save_cross_section_files(
-        const CrossSection& cross_section, absl::string_view directory ) const
+        const CrossSection& cross_section, std::string_view directory ) const
     {
         async::parallel_invoke(
             [&directory, &cross_section] {

--- a/src/geode/geosciences/explicit/representation/io/geode/geode_structural_model_input.cpp
+++ b/src/geode/geosciences/explicit/representation/io/geode/geode_structural_model_input.cpp
@@ -47,13 +47,13 @@
 namespace geode
 {
     OpenGeodeStructuralModelInput::OpenGeodeStructuralModelInput(
-        absl::string_view filename )
+        std::string_view filename )
         : StructuralModelInput{ filename }
     {
     }
 
     void OpenGeodeStructuralModelInput::load_structural_model_files(
-        StructuralModel& structural_model, absl::string_view directory )
+        StructuralModel& structural_model, std::string_view directory )
     {
         StructuralModelBuilder builder{ structural_model };
         async::parallel_invoke(

--- a/src/geode/geosciences/explicit/representation/io/geode/geode_structural_model_output.cpp
+++ b/src/geode/geosciences/explicit/representation/io/geode/geode_structural_model_output.cpp
@@ -38,14 +38,14 @@
 namespace geode
 {
     OpenGeodeStructuralModelOutput::OpenGeodeStructuralModelOutput(
-        absl::string_view filename )
+        std::string_view filename )
         : StructuralModelOutput( filename )
     {
     }
 
     void OpenGeodeStructuralModelOutput::save_structural_model_files(
         const StructuralModel& structural_model,
-        absl::string_view directory ) const
+        std::string_view directory ) const
     {
         async::parallel_invoke(
             [&directory, &structural_model] {

--- a/src/geode/geosciences/explicit/representation/io/structural_model_input.cpp
+++ b/src/geode/geosciences/explicit/representation/io/structural_model_input.cpp
@@ -23,8 +23,9 @@
 
 #include <geode/geosciences/explicit/representation/io/structural_model_input.h>
 
+#include <string_view>
+
 #include <absl/strings/str_cat.h>
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/detail/geode_input_impl.h>
 #include <geode/basic/io.h>
@@ -36,7 +37,7 @@
 
 namespace geode
 {
-    StructuralModel load_structural_model( absl::string_view filename )
+    StructuralModel load_structural_model( std::string_view filename )
     {
         constexpr auto TYPE = "StructuralModel";
         try
@@ -79,7 +80,7 @@ namespace geode
     }
 
     typename StructuralModelInput::MissingFiles
-        check_structural_model_missing_files( absl::string_view filename )
+        check_structural_model_missing_files( std::string_view filename )
     {
         const auto input =
             detail::geode_object_input_reader< StructuralModelInputFactory >(
@@ -87,7 +88,7 @@ namespace geode
         return input->check_missing_files();
     }
 
-    bool is_structural_model_loadable( absl::string_view filename )
+    bool is_structural_model_loadable( std::string_view filename )
     {
         const auto input =
             detail::geode_object_input_reader< StructuralModelInputFactory >(

--- a/src/geode/geosciences/explicit/representation/io/structural_model_output.cpp
+++ b/src/geode/geosciences/explicit/representation/io/structural_model_output.cpp
@@ -24,9 +24,8 @@
 #include <geode/geosciences/explicit/representation/io/structural_model_output.h>
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/detail/geode_output_impl.h>
 #include <geode/basic/io.h>
@@ -39,7 +38,7 @@
 namespace geode
 {
     std::vector< std::string > save_structural_model(
-        const StructuralModel& structural_model, absl::string_view filename )
+        const StructuralModel& structural_model, std::string_view filename )
     {
         constexpr auto TYPE = "StructuralModel";
         try
@@ -60,7 +59,7 @@ namespace geode
     }
 
     bool is_structural_model_saveable(
-        const StructuralModel& structural_model, absl::string_view filename )
+        const StructuralModel& structural_model, std::string_view filename )
     {
         const auto output =
             detail::geode_object_output_writer< StructuralModelOutputFactory >(

--- a/src/geode/geosciences/implicit/mixin/builder/stratigraphic_relationships_builder.cpp
+++ b/src/geode/geosciences/implicit/mixin/builder/stratigraphic_relationships_builder.cpp
@@ -82,7 +82,7 @@ namespace geode
     }
 
     void StratigraphicRelationshipsBuilder::load_stratigraphic_relationships(
-        absl::string_view directory )
+        std::string_view directory )
     {
         relationships_.load_stratigraphic_relationships( directory, {} );
     }

--- a/src/geode/geosciences/implicit/mixin/core/stratigraphic_relationships.cpp
+++ b/src/geode/geosciences/implicit/mixin/core/stratigraphic_relationships.cpp
@@ -113,12 +113,12 @@ namespace geode
                    == baselap;
         }
 
-        absl::optional< uuid > above( const uuid& element ) const
+        std::optional< uuid > above( const uuid& element ) const
         {
             const auto index_from = vertex_id( element );
             if( !index_from )
             {
-                return absl::nullopt;
+                return std::nullopt;
             }
             for( const auto& edge_vertex :
                 this->graph().edges_around_vertex( index_from.value() ) )
@@ -133,15 +133,15 @@ namespace geode
                         .id();
                 }
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
-        absl::optional< uuid > under( const uuid& element ) const
+        std::optional< uuid > under( const uuid& element ) const
         {
             const auto index_from = vertex_id( element );
             if( !index_from )
             {
-                return absl::nullopt;
+                return std::nullopt;
             }
             for( const auto& edge_vertex :
                 this->graph().edges_around_vertex( index_from.value() ) )
@@ -156,7 +156,7 @@ namespace geode
                         .id();
                 }
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         index_t add_above_relation(
@@ -292,18 +292,18 @@ namespace geode
                         "geode_unconformities", NO_UNCONFORMITY );
         }
 
-        absl::optional< index_t > relation_edge(
+        std::optional< index_t > relation_edge(
             const uuid& from, const uuid& to ) const
         {
             const auto index_from = vertex_id( from );
             if( !index_from )
             {
-                return absl::nullopt;
+                return std::nullopt;
             }
             const auto index_to = vertex_id( to );
             if( !index_to )
             {
-                return absl::nullopt;
+                return std::nullopt;
             }
             for( const auto& edge_vertex :
                 this->graph().edges_around_vertex( index_from.value() ) )
@@ -315,7 +315,7 @@ namespace geode
                     return edge_vertex.edge_id;
                 }
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         void remove_relation_edge( index_t relation_edge_id )
@@ -376,13 +376,13 @@ namespace geode
         return impl_->is_baselap_of( baselap, baselap_top );
     }
 
-    absl::optional< uuid > StratigraphicRelationships::above(
+    std::optional< uuid > StratigraphicRelationships::above(
         const uuid& element ) const
     {
         return impl_->above( element );
     }
 
-    absl::optional< uuid > StratigraphicRelationships::under(
+    std::optional< uuid > StratigraphicRelationships::under(
         const uuid& element ) const
     {
         return impl_->under( element );

--- a/src/geode/geosciences/implicit/mixin/core/stratigraphic_relationships.cpp
+++ b/src/geode/geosciences/implicit/mixin/core/stratigraphic_relationships.cpp
@@ -245,7 +245,7 @@ namespace geode
             initialize_relation_attributes();
         }
 
-        void save( absl::string_view directory ) const
+        void save( std::string_view directory ) const
         {
             const auto filename =
                 absl::StrCat( directory, "/stratigraphic_relationships" );
@@ -260,7 +260,7 @@ namespace geode
                 "[Relationships::save] Error while writing file: ", filename );
         }
 
-        void load( absl::string_view directory )
+        void load( std::string_view directory )
         {
             const auto filename =
                 absl::StrCat( directory, "/stratigraphic_relationships" );
@@ -431,7 +431,7 @@ namespace geode
     }
 
     void StratigraphicRelationships::save_stratigraphic_relationships(
-        absl::string_view directory ) const
+        std::string_view directory ) const
     {
         impl_->save( directory );
     }
@@ -445,7 +445,7 @@ namespace geode
     }
 
     void StratigraphicRelationships::load_stratigraphic_relationships(
-        absl::string_view directory, StratigraphicRelationshipsBuilderKey )
+        std::string_view directory, StratigraphicRelationshipsBuilderKey )
     {
         return impl_->load( directory );
     }

--- a/src/geode/geosciences/implicit/representation/builder/implicit_cross_section_builder.cpp
+++ b/src/geode/geosciences/implicit/representation/builder/implicit_cross_section_builder.cpp
@@ -100,6 +100,8 @@ namespace geode
 
     HorizonsStackBuilder2D ImplicitCrossSectionBuilder::horizons_stack_builder()
     {
-        return { implicit_section_.modifiable_horizons_stack( {} ) };
+        return HorizonsStackBuilder2D{
+            implicit_section_.modifiable_horizons_stack( {} )
+        };
     }
 } // namespace geode

--- a/src/geode/geosciences/implicit/representation/builder/implicit_structural_model_builder.cpp
+++ b/src/geode/geosciences/implicit/representation/builder/implicit_structural_model_builder.cpp
@@ -104,6 +104,8 @@ namespace geode
     HorizonsStackBuilder3D
         ImplicitStructuralModelBuilder::horizons_stack_builder()
     {
-        return { implicit_model_.modifiable_horizons_stack( {} ) };
+        return HorizonsStackBuilder3D{
+            implicit_model_.modifiable_horizons_stack( {} )
+        };
     }
 } // namespace geode

--- a/src/geode/geosciences/implicit/representation/core/detail/helpers.cpp
+++ b/src/geode/geosciences/implicit/representation/core/detail/helpers.cpp
@@ -344,7 +344,7 @@ namespace geode
             }
             index_t horizon_counter{ 1 };
             auto su_above = horizon_stack.above( bottom_horizon );
-            absl::optional< uuid > current_horizon = bottom_horizon;
+            std::optional< uuid > current_horizon = bottom_horizon;
             while( su_above )
             {
                 current_horizon = horizon_stack.above( su_above.value() );

--- a/src/geode/geosciences/implicit/representation/core/detail/helpers.cpp
+++ b/src/geode/geosciences/implicit/representation/core/detail/helpers.cpp
@@ -132,7 +132,7 @@ namespace geode
 
         void save_stratigraphic_surfaces(
             const StratigraphicSection& implicit_model,
-            absl::string_view prefix )
+            std::string_view prefix )
         {
             index_t counter{ 0 };
             for( const auto& surface : implicit_model.surfaces() )
@@ -163,7 +163,7 @@ namespace geode
 
         void save_stratigraphic_blocks(
             const geode::StratigraphicModel& implicit_model,
-            absl::string_view prefix )
+            std::string_view prefix )
         {
             index_t counter{ 0 };
             for( const auto& block : implicit_model.blocks() )
@@ -193,7 +193,7 @@ namespace geode
         }
 
         ImplicitCrossSection implicit_section_from_cross_section_scalar_field(
-            CrossSection&& section, absl::string_view scalar_attribute_name )
+            CrossSection&& section, std::string_view scalar_attribute_name )
         {
             for( const auto& surface : section.surfaces() )
             {
@@ -222,7 +222,7 @@ namespace geode
         ImplicitStructuralModel
             implicit_model_from_structural_model_scalar_field(
                 StructuralModel&& model,
-                absl::string_view scalar_attribute_name )
+                std::string_view scalar_attribute_name )
         {
             for( const auto& block : model.blocks() )
             {

--- a/src/geode/geosciences/implicit/representation/core/detail/helpers.cpp
+++ b/src/geode/geosciences/implicit/representation/core/detail/helpers.cpp
@@ -207,7 +207,7 @@ namespace geode
                     surface_mesh.vertex_attribute_manager()
                         .find_or_create_attribute< VariableAttribute,
                             ImplicitCrossSection::implicit_attribute_type >(
-                            ImplicitCrossSection::implicit_attribute_name, 0,
+                            ImplicitCrossSection::IMPLICIT_ATTRIBUTE_NAME, 0,
                             { false, true } );
                 for( const auto vertex_id :
                     Range{ surface_mesh.nb_vertices() } )
@@ -236,7 +236,7 @@ namespace geode
                     block_mesh.vertex_attribute_manager()
                         .find_or_create_attribute< VariableAttribute,
                             ImplicitStructuralModel::implicit_attribute_type >(
-                            ImplicitStructuralModel::implicit_attribute_name, 0,
+                            ImplicitStructuralModel::IMPLICIT_ATTRIBUTE_NAME, 0,
                             { false, true } );
                 for( const auto vertex_id : Range{ block_mesh.nb_vertices() } )
                 {
@@ -265,7 +265,7 @@ namespace geode
                         .find_or_create_attribute< VariableAttribute,
                             StratigraphicModel::stratigraphic_location_type >(
                             StratigraphicModel::
-                                stratigraphic_location_attribute_name,
+                                STRATIGRAPHIC_LOCATION_ATTRIBUTE_NAME,
                             Point2D{ { 0, 0 } }, { false, true } );
                 for( const auto vertex_id : Range{ block_mesh.nb_vertices() } )
                 {

--- a/src/geode/geosciences/implicit/representation/core/detail/helpers.cpp
+++ b/src/geode/geosciences/implicit/representation/core/detail/helpers.cpp
@@ -144,7 +144,7 @@ namespace geode
                 auto xyz_attribute =
                     strati_surface->vertex_attribute_manager()
                         .find_or_create_attribute< VariableAttribute, Point2D >(
-                            "geode_xyz", { { 0, 0 } }, { false, true } );
+                            "geode_xyz", Point2D{ { 0, 0 } }, { false, true } );
                 for( const auto pt_id : Range{ strati_surface->nb_vertices() } )
                 {
                     xyz_attribute->set_value(
@@ -174,7 +174,8 @@ namespace geode
                 auto xyz_attribute =
                     strati_solid->vertex_attribute_manager()
                         .find_or_create_attribute< VariableAttribute, Point3D >(
-                            "geode_xyz", { { 0, 0, 0 } }, { false, true } );
+                            "geode_xyz", Point3D{ { 0, 0, 0 } },
+                            { false, true } );
                 for( const auto pt_id : Range{ strati_solid->nb_vertices() } )
                 {
                     xyz_attribute->set_value(
@@ -265,12 +266,12 @@ namespace geode
                             StratigraphicModel::stratigraphic_location_type >(
                             StratigraphicModel::
                                 stratigraphic_location_attribute_name,
-                            { { 0, 0 } }, { false, true } );
+                            Point2D{ { 0, 0 } }, { false, true } );
                 for( const auto vertex_id : Range{ block_mesh.nb_vertices() } )
                 {
                     const auto& vertex_point = block_mesh.point( vertex_id );
                     strati_location_attribute->set_value(
-                        vertex_id, { { vertex_point.value( first_axis ),
+                        vertex_id, Point2D{ { vertex_point.value( first_axis ),
                                        vertex_point.value( second_axis ) } } );
                 }
             }

--- a/src/geode/geosciences/implicit/representation/core/horizons_stack.cpp
+++ b/src/geode/geosciences/implicit/representation/core/horizons_stack.cpp
@@ -29,9 +29,7 @@
 namespace geode
 {
     template < index_t dimension >
-    HorizonsStack< dimension >::HorizonsStack()
-    {
-    }
+    HorizonsStack< dimension >::HorizonsStack() = default;
 
     template < index_t dimension >
     HorizonsStack< dimension >::HorizonsStack(

--- a/src/geode/geosciences/implicit/representation/core/implicit_cross_section.cpp
+++ b/src/geode/geosciences/implicit/representation/core/implicit_cross_section.cpp
@@ -223,19 +223,19 @@ namespace geode
                     "with uuid '",
                     surface.id().string(), "'." );
                 if( !surface.mesh().vertex_attribute_manager().attribute_exists(
-                        implicit_attribute_name ) )
+                        IMPLICIT_ATTRIBUTE_NAME ) )
                 {
                     implicit_attributes_.try_emplace( surface.id(),
                         TriangulatedSurfaceScalarFunction2D::create(
                             surface.mesh< TriangulatedSurface2D >(),
-                            implicit_attribute_name, 0 ) );
+                            IMPLICIT_ATTRIBUTE_NAME, 0 ) );
                 }
                 else
                 {
                     implicit_attributes_.try_emplace( surface.id(),
                         TriangulatedSurfaceScalarFunction2D::find(
                             surface.mesh< TriangulatedSurface2D >(),
-                            implicit_attribute_name ) );
+                            IMPLICIT_ATTRIBUTE_NAME ) );
                 }
             }
         }

--- a/src/geode/geosciences/implicit/representation/core/implicit_cross_section.cpp
+++ b/src/geode/geosciences/implicit/representation/core/implicit_cross_section.cpp
@@ -104,7 +104,7 @@ namespace geode
                         surface_distance_to_triangles_.at( surface.id() ) ) );
             if( std::get< 0 >( surface_distance_to_triangles_.at(
                     surface.id() )( point, closest_triangle ) )
-                < global_epsilon )
+                < GLOBAL_EPSILON )
             {
                 return closest_triangle;
             }

--- a/src/geode/geosciences/implicit/representation/core/implicit_cross_section.cpp
+++ b/src/geode/geosciences/implicit/representation/core/implicit_cross_section.cpp
@@ -74,7 +74,7 @@ namespace geode
             return implicit_attributes_.at( surface.id() ).value( vertex_id );
         }
 
-        absl::optional< double > implicit_value(
+        std::optional< double > implicit_value(
             const Surface2D& surface, const Point2D& point ) const
         {
             if( const auto containing_triangle =
@@ -83,7 +83,7 @@ namespace geode
                 return implicit_value(
                     surface, point, containing_triangle.value() );
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         double implicit_value( const Surface2D& surface,
@@ -94,7 +94,7 @@ namespace geode
                 .value( point, triangle_id );
         }
 
-        absl::optional< index_t > containing_polygon(
+        std::optional< index_t > containing_polygon(
             const Surface2D& surface, const Point2D& point ) const
         {
             const auto closest_triangle = std::get< 0 >(
@@ -108,7 +108,7 @@ namespace geode
             {
                 return closest_triangle;
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         const HorizonsStack2D& horizons_stack() const
@@ -121,7 +121,7 @@ namespace geode
             return horizons_stack_;
         }
 
-        absl::optional< double > horizon_implicit_value(
+        std::optional< double > horizon_implicit_value(
             const Horizon2D& horizon ) const
         {
             OPENGEODE_EXCEPTION( horizons_stack_.has_horizon( horizon.id() ),
@@ -133,7 +133,7 @@ namespace geode
             const auto value = horizon_isovalues_.find( horizon.id() );
             if( value == horizon_isovalues_.end() )
             {
-                return absl::nullopt;
+                return std::nullopt;
             }
             return value->second;
         }
@@ -154,17 +154,17 @@ namespace geode
                    == ( implicit_function_value >= it->second );
         }
 
-        absl::optional< uuid > containing_stratigraphic_unit(
+        std::optional< uuid > containing_stratigraphic_unit(
             double implicit_function_value ) const
         {
             if( horizon_isovalues_.empty() )
             {
-                return absl::nullopt;
+                return std::nullopt;
             }
             const auto increasing = increasing_stack_isovalues();
             if( !increasing.has_value() )
             {
-                return absl::nullopt;
+                return std::nullopt;
             }
             auto horizon_id = horizon_isovalues_.begin()->first;
             while( true )
@@ -176,7 +176,7 @@ namespace geode
                     const auto unit_above = horizons_stack_.above( horizon_id );
                     if( !unit_above )
                     {
-                        return absl::nullopt;
+                        return std::nullopt;
                     }
                     const auto horizon_above =
                         horizons_stack_.above( unit_above.value() );
@@ -193,7 +193,7 @@ namespace geode
                 const auto unit_under = horizons_stack_.under( horizon_id );
                 if( !unit_under )
                 {
-                    return absl::nullopt;
+                    return std::nullopt;
                 }
                 const auto horizon_under =
                     horizons_stack_.under( unit_under.value() );
@@ -270,7 +270,7 @@ namespace geode
         }
 
     private:
-        absl::optional< bool > increasing_stack_isovalues() const
+        std::optional< bool > increasing_stack_isovalues() const
         {
             for( const auto& unit : horizons_stack_.stratigraphic_units() )
             {
@@ -283,12 +283,12 @@ namespace geode
                     if( it0 == horizon_isovalues_.end()
                         || it1 == horizon_isovalues_.end() )
                     {
-                        return absl::nullopt;
+                        return std::nullopt;
                     }
                     return it0->second > it1->second;
                 }
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         friend class bitsery::Access;
@@ -370,7 +370,7 @@ namespace geode
         return impl_->implicit_value( surface, vertex_id );
     }
 
-    absl::optional< double > ImplicitCrossSection::implicit_value(
+    std::optional< double > ImplicitCrossSection::implicit_value(
         const Surface2D& surface, const Point2D& point ) const
     {
         return impl_->implicit_value( surface, point );
@@ -383,7 +383,7 @@ namespace geode
         return impl_->implicit_value( surface, point, polygon_id );
     }
 
-    absl::optional< index_t > ImplicitCrossSection::containing_polygon(
+    std::optional< index_t > ImplicitCrossSection::containing_polygon(
         const Surface2D& surface, const Point2D& point ) const
     {
         return impl_->containing_polygon( surface, point );
@@ -394,7 +394,7 @@ namespace geode
         return impl_->horizons_stack();
     }
 
-    absl::optional< double > ImplicitCrossSection::horizon_implicit_value(
+    std::optional< double > ImplicitCrossSection::horizon_implicit_value(
         const Horizon2D& horizon ) const
     {
         return horizon_implicit_value( horizon );
@@ -407,7 +407,7 @@ namespace geode
             implicit_function_value, horizon );
     }
 
-    absl::optional< uuid > ImplicitCrossSection::containing_stratigraphic_unit(
+    std::optional< uuid > ImplicitCrossSection::containing_stratigraphic_unit(
         double implicit_function_value ) const
     {
         return impl_->containing_stratigraphic_unit( implicit_function_value );

--- a/src/geode/geosciences/implicit/representation/core/implicit_cross_section.cpp
+++ b/src/geode/geosciences/implicit/representation/core/implicit_cross_section.cpp
@@ -102,8 +102,8 @@ namespace geode
                     .at( surface.id() )( create_aabb_tree, surface.mesh() )
                     .closest_element_box( point,
                         surface_distance_to_triangles_.at( surface.id() ) ) );
-            if( std::get< 0 >( surface_distance_to_triangles_.at(
-                    surface.id() )( point, closest_triangle ) )
+            if( surface_distance_to_triangles_.at( surface.id() )(
+                    point, closest_triangle )
                 < GLOBAL_EPSILON )
             {
                 return closest_triangle;

--- a/src/geode/geosciences/implicit/representation/core/implicit_structural_model.cpp
+++ b/src/geode/geosciences/implicit/representation/core/implicit_structural_model.cpp
@@ -102,8 +102,8 @@ namespace geode
                     .at( block.id() )( create_aabb_tree, block.mesh() )
                     .closest_element_box(
                         point, block_distance_to_tetras_.at( block.id() ) ) );
-            if( std::get< 0 >( block_distance_to_tetras_.at( block.id() )(
-                    point, closest_tetrahedron ) )
+            if( block_distance_to_tetras_.at( block.id() )(
+                    point, closest_tetrahedron )
                 < GLOBAL_EPSILON )
             {
                 return closest_tetrahedron;

--- a/src/geode/geosciences/implicit/representation/core/implicit_structural_model.cpp
+++ b/src/geode/geosciences/implicit/representation/core/implicit_structural_model.cpp
@@ -225,19 +225,19 @@ namespace geode
                     "which is not the case for block with uuid '",
                     block.id().string(), "'." );
                 if( !block.mesh().vertex_attribute_manager().attribute_exists(
-                        implicit_attribute_name ) )
+                        IMPLICIT_ATTRIBUTE_NAME ) )
                 {
                     implicit_attributes_.try_emplace(
                         block.id(), TetrahedralSolidScalarFunction3D::create(
                                         block.mesh< TetrahedralSolid3D >(),
-                                        implicit_attribute_name, 0 ) );
+                                        IMPLICIT_ATTRIBUTE_NAME, 0 ) );
                 }
                 else
                 {
                     implicit_attributes_.try_emplace(
                         block.id(), TetrahedralSolidScalarFunction3D::find(
                                         block.mesh< TetrahedralSolid3D >(),
-                                        implicit_attribute_name ) );
+                                        IMPLICIT_ATTRIBUTE_NAME ) );
                 }
             }
         }

--- a/src/geode/geosciences/implicit/representation/core/implicit_structural_model.cpp
+++ b/src/geode/geosciences/implicit/representation/core/implicit_structural_model.cpp
@@ -104,7 +104,7 @@ namespace geode
                         point, block_distance_to_tetras_.at( block.id() ) ) );
             if( std::get< 0 >( block_distance_to_tetras_.at( block.id() )(
                     point, closest_tetrahedron ) )
-                < global_epsilon )
+                < GLOBAL_EPSILON )
             {
                 return closest_tetrahedron;
             }

--- a/src/geode/geosciences/implicit/representation/core/implicit_structural_model.cpp
+++ b/src/geode/geosciences/implicit/representation/core/implicit_structural_model.cpp
@@ -75,7 +75,7 @@ namespace geode
             return implicit_attributes_.at( block.id() ).value( vertex_id );
         }
 
-        absl::optional< double > implicit_value(
+        std::optional< double > implicit_value(
             const Block3D& block, const Point3D& point ) const
         {
             if( const auto containing_tetra =
@@ -83,7 +83,7 @@ namespace geode
             {
                 return implicit_value( block, point, containing_tetra.value() );
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         double implicit_value( const Block3D& block,
@@ -94,7 +94,7 @@ namespace geode
                 .value( point, tetrahedron_id );
         }
 
-        absl::optional< index_t > containing_polyhedron(
+        std::optional< index_t > containing_polyhedron(
             const Block3D& block, const Point3D& point ) const
         {
             auto closest_tetrahedron = std::get< 0 >(
@@ -108,7 +108,7 @@ namespace geode
             {
                 return closest_tetrahedron;
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         const HorizonsStack3D& horizons_stack() const
@@ -121,7 +121,7 @@ namespace geode
             return horizons_stack_;
         }
 
-        absl::optional< double > horizon_implicit_value(
+        std::optional< double > horizon_implicit_value(
             const Horizon3D& horizon ) const
         {
             OPENGEODE_EXCEPTION( horizons_stack_.has_horizon( horizon.id() ),
@@ -132,7 +132,7 @@ namespace geode
             const auto value = horizon_isovalues_.find( horizon.id() );
             if( value == horizon_isovalues_.end() )
             {
-                return absl::nullopt;
+                return std::nullopt;
             }
             return value->second;
         }
@@ -153,17 +153,17 @@ namespace geode
                    == ( implicit_function_value >= it->second );
         }
 
-        absl::optional< uuid > containing_stratigraphic_unit(
+        std::optional< uuid > containing_stratigraphic_unit(
             double implicit_function_value ) const
         {
             if( horizon_isovalues_.empty() )
             {
-                return absl::nullopt;
+                return std::nullopt;
             }
             const auto increasing = increasing_stack_isovalues();
             if( !increasing.has_value() )
             {
-                return absl::nullopt;
+                return std::nullopt;
             }
             auto horizon_id = horizon_isovalues_.begin()->first;
             while( true )
@@ -175,7 +175,7 @@ namespace geode
                     const auto unit_above = horizons_stack_.above( horizon_id );
                     if( !unit_above )
                     {
-                        return absl::nullopt;
+                        return std::nullopt;
                     }
                     const auto horizon_above =
                         horizons_stack_.above( unit_above.value() );
@@ -192,7 +192,7 @@ namespace geode
                 const auto unit_under = horizons_stack_.under( horizon_id );
                 if( !unit_under )
                 {
-                    return absl::nullopt;
+                    return std::nullopt;
                 }
                 const auto horizon_under =
                     horizons_stack_.under( unit_under.value() );
@@ -275,7 +275,7 @@ namespace geode
             return block.mesh().nb_polyhedra() != 0;
         }
 
-        absl::optional< bool > increasing_stack_isovalues() const
+        std::optional< bool > increasing_stack_isovalues() const
         {
             for( const auto& unit : horizons_stack_.stratigraphic_units() )
             {
@@ -288,12 +288,12 @@ namespace geode
                     if( it0 == horizon_isovalues_.end()
                         || it1 == horizon_isovalues_.end() )
                     {
-                        return absl::nullopt;
+                        return std::nullopt;
                     }
                     return it0->second > it1->second;
                 }
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         friend class bitsery::Access;
@@ -376,7 +376,7 @@ namespace geode
         return impl_->implicit_value( block, vertex_id );
     }
 
-    absl::optional< double > ImplicitStructuralModel::implicit_value(
+    std::optional< double > ImplicitStructuralModel::implicit_value(
         const Block3D& block, const Point3D& point ) const
     {
         return impl_->implicit_value( block, point );
@@ -388,7 +388,7 @@ namespace geode
     {
         return impl_->implicit_value( block, point, polyhedron_id );
     }
-    absl::optional< index_t > ImplicitStructuralModel::containing_polyhedron(
+    std::optional< index_t > ImplicitStructuralModel::containing_polyhedron(
         const Block3D& block, const Point3D& point ) const
     {
         return impl_->containing_polyhedron( block, point );
@@ -399,7 +399,7 @@ namespace geode
         return impl_->horizons_stack();
     }
 
-    absl::optional< double > ImplicitStructuralModel::horizon_implicit_value(
+    std::optional< double > ImplicitStructuralModel::horizon_implicit_value(
         const Horizon3D& horizon ) const
     {
         return impl_->horizon_implicit_value( horizon );
@@ -412,7 +412,7 @@ namespace geode
             implicit_function_value, horizon );
     }
 
-    absl::optional< uuid >
+    std::optional< uuid >
         ImplicitStructuralModel::containing_stratigraphic_unit(
             double implicit_function_value ) const
     {

--- a/src/geode/geosciences/implicit/representation/core/stratigraphic_model.cpp
+++ b/src/geode/geosciences/implicit/representation/core/stratigraphic_model.cpp
@@ -157,7 +157,7 @@ namespace geode
                         block.id() ) ) );
             if( std::get< 0 >( block_stratigraphic_distance_to_tetras_.at(
                     block.id() )( stratigraphic_point, closest_tetrahedron ) )
-                < global_epsilon )
+                < GLOBAL_EPSILON )
             {
                 return closest_tetrahedron;
             }

--- a/src/geode/geosciences/implicit/representation/core/stratigraphic_model.cpp
+++ b/src/geode/geosciences/implicit/representation/core/stratigraphic_model.cpp
@@ -208,7 +208,7 @@ namespace geode
                         TetrahedralSolidPointFunction< 3, 2 >::create(
                             block.mesh< TetrahedralSolid3D >(),
                             stratigraphic_location_attribute_name,
-                            { { 0, 0 } } ) );
+                            Point2D{ { 0, 0 } } ) );
                 }
                 else
                 {
@@ -334,7 +334,7 @@ namespace geode
                     }
                     box_vector[p] = std::move( bbox );
                 } );
-            return { box_vector };
+            return AABBTree3D{ std::move( box_vector ) };
         }
 
         void build_model_stratigraphic_distance_to_mesh_elements(

--- a/src/geode/geosciences/implicit/representation/core/stratigraphic_model.cpp
+++ b/src/geode/geosciences/implicit/representation/core/stratigraphic_model.cpp
@@ -79,7 +79,7 @@ namespace geode
                 model.implicit_value( block, vertex_id ) };
         }
 
-        absl::optional< StratigraphicPoint3D > stratigraphic_coordinates(
+        std::optional< StratigraphicPoint3D > stratigraphic_coordinates(
             const StratigraphicModel& model,
             const Block3D& block,
             const Point3D& geometric_point ) const
@@ -90,7 +90,7 @@ namespace geode
                 return stratigraphic_coordinates(
                     model, block, geometric_point, containing_tetra.value() );
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         StratigraphicPoint3D stratigraphic_coordinates(
@@ -105,7 +105,7 @@ namespace geode
                     block, geometric_point, tetrahedron_id ) };
         }
 
-        absl::optional< Point3D > geometric_coordinates(
+        std::optional< Point3D > geometric_coordinates(
             const StratigraphicModel& model,
             const Block3D& block,
             const StratigraphicPoint3D& stratigraphic_point ) const
@@ -117,7 +117,7 @@ namespace geode
                 return geometric_coordinates( model, block, stratigraphic_point,
                     containing_tetra.value() );
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         Point3D geometric_coordinates( const StratigraphicModel& model,
@@ -142,7 +142,7 @@ namespace geode
             return geometric_point;
         }
 
-        absl::optional< index_t > stratigraphic_containing_polyhedron(
+        std::optional< index_t > stratigraphic_containing_polyhedron(
             const StratigraphicModel& model,
             const Block3D& block,
             const StratigraphicPoint3D& stratigraphic_point ) const
@@ -161,7 +161,7 @@ namespace geode
             {
                 return closest_tetrahedron;
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         absl::InlinedVector< std::unique_ptr< TriangulatedSurface3D >, 2 >
@@ -526,7 +526,7 @@ namespace geode
         return impl_->stratigraphic_coordinates( *this, block, vertex_id );
     }
 
-    absl::optional< StratigraphicPoint3D >
+    std::optional< StratigraphicPoint3D >
         StratigraphicModel::stratigraphic_coordinates(
             const Block3D& block, const Point3D& geometric_point ) const
     {
@@ -543,7 +543,7 @@ namespace geode
             *this, block, geometric_point, polyhedron_id );
     }
 
-    absl::optional< Point3D > StratigraphicModel::geometric_coordinates(
+    std::optional< Point3D > StratigraphicModel::geometric_coordinates(
         const Block3D& block,
         const StratigraphicPoint3D& stratigraphic_point ) const
     {
@@ -559,7 +559,7 @@ namespace geode
             *this, block, stratigraphic_point, polyhedron_id );
     }
 
-    absl::optional< index_t >
+    std::optional< index_t >
         StratigraphicModel::stratigraphic_containing_polyhedron(
             const Block3D& block,
             const StratigraphicPoint3D& stratigraphic_point ) const

--- a/src/geode/geosciences/implicit/representation/core/stratigraphic_model.cpp
+++ b/src/geode/geosciences/implicit/representation/core/stratigraphic_model.cpp
@@ -155,8 +155,8 @@ namespace geode
                     stratigraphic_point.stratigraphic_coordinates(),
                     block_stratigraphic_distance_to_tetras_.at(
                         block.id() ) ) );
-            if( std::get< 0 >( block_stratigraphic_distance_to_tetras_.at(
-                    block.id() )( stratigraphic_point, closest_tetrahedron ) )
+            if( block_stratigraphic_distance_to_tetras_.at( block.id() )(
+                    stratigraphic_point, closest_tetrahedron )
                 < GLOBAL_EPSILON )
             {
                 return closest_tetrahedron;
@@ -262,7 +262,7 @@ namespace geode
                 const Block3D& block,
                 index_t tetrahedron_id )
                 : indices_{ block.mesh().polyhedron_vertices(
-                    tetrahedron_id ) },
+                      tetrahedron_id ) },
                   positive_tetra_{
                       model.stratigraphic_coordinates( block, indices_[0] )
                           .stratigraphic_coordinates(),
@@ -297,15 +297,15 @@ namespace geode
             {
             }
 
-            std::tuple< double, Point3D > operator()(
+            double operator()(
                 const StratigraphicPoint3D& query, index_t cur_box ) const
             {
                 auto positive_tetra =
                     PositiveStratigraphicTetrahedron{ model_, block_, cur_box };
-                auto dist = point_tetrahedron_distance(
+                auto output = point_tetrahedron_distance(
                     query.stratigraphic_coordinates(),
                     positive_tetra.positive_tetra_ );
-                return dist;
+                return std::get< 0 >( output );
             }
 
         private:

--- a/src/geode/geosciences/implicit/representation/core/stratigraphic_model.cpp
+++ b/src/geode/geosciences/implicit/representation/core/stratigraphic_model.cpp
@@ -262,7 +262,7 @@ namespace geode
                 const Block3D& block,
                 index_t tetrahedron_id )
                 : indices_{ block.mesh().polyhedron_vertices(
-                      tetrahedron_id ) },
+                    tetrahedron_id ) },
                   positive_tetra_{
                       model.stratigraphic_coordinates( block, indices_[0] )
                           .stratigraphic_coordinates(),

--- a/src/geode/geosciences/implicit/representation/core/stratigraphic_model.cpp
+++ b/src/geode/geosciences/implicit/representation/core/stratigraphic_model.cpp
@@ -202,12 +202,12 @@ namespace geode
                     "with uuid '",
                     block.id().string(), "'." );
                 if( !block.mesh().vertex_attribute_manager().attribute_exists(
-                        stratigraphic_location_attribute_name ) )
+                        STRATIGRAPHIC_LOCATION_ATTRIBUTE_NAME ) )
                 {
                     stratigraphic_location_attributes_.try_emplace( block.id(),
                         TetrahedralSolidPointFunction< 3, 2 >::create(
                             block.mesh< TetrahedralSolid3D >(),
-                            stratigraphic_location_attribute_name,
+                            STRATIGRAPHIC_LOCATION_ATTRIBUTE_NAME,
                             Point2D{ { 0, 0 } } ) );
                 }
                 else
@@ -215,7 +215,7 @@ namespace geode
                     stratigraphic_location_attributes_.try_emplace( block.id(),
                         TetrahedralSolidPointFunction< 3, 2 >::find(
                             block.mesh< TetrahedralSolid3D >(),
-                            stratigraphic_location_attribute_name ) );
+                            STRATIGRAPHIC_LOCATION_ATTRIBUTE_NAME ) );
                 }
             }
         }
@@ -262,7 +262,7 @@ namespace geode
                 const Block3D& block,
                 index_t tetrahedron_id )
                 : indices_{ block.mesh().polyhedron_vertices(
-                    tetrahedron_id ) },
+                      tetrahedron_id ) },
                   positive_tetra_{
                       model.stratigraphic_coordinates( block, indices_[0] )
                           .stratigraphic_coordinates(),
@@ -360,7 +360,7 @@ namespace geode
                 strati_surface->polygon_attribute_manager()
                     .find_or_create_attribute< VariableAttribute,
                         PolyhedronFacet >(
-                        stratigraphic_surface_polyhedron_facet_attribute_name,
+                        STRATIGRAPHIC_SURFACE_POLYHEDRON_FACET_ATTRIBUTE_NAME,
                         {} );
             const auto& surface_mesh = surface.mesh< TriangulatedSurface3D >();
             std::vector< bool > vertices_checked(
@@ -419,7 +419,7 @@ namespace geode
                         ->polygon_attribute_manager()
                         .find_or_create_attribute< VariableAttribute,
                             PolyhedronFacet >(
-                            stratigraphic_surface_polyhedron_facet_attribute_name,
+                            STRATIGRAPHIC_SURFACE_POLYHEDRON_FACET_ATTRIBUTE_NAME,
                             {} );
             }
             std::vector< bool > vertices_checked(

--- a/src/geode/geosciences/implicit/representation/core/stratigraphic_section.cpp
+++ b/src/geode/geosciences/implicit/representation/core/stratigraphic_section.cpp
@@ -223,7 +223,7 @@ namespace geode
                         TriangulatedSurfacePointFunction< 2, 1 >::create(
                             surface.mesh< TriangulatedSurface2D >(),
                             stratigraphic_location_attribute_name,
-                            { { 0 } } ) );
+                            Point1D{ { 0 } } ) );
                 }
                 else
                 {
@@ -330,7 +330,7 @@ namespace geode
                     }
                     box_vector[p] = std::move( bbox );
                 } );
-            return { box_vector };
+            return AABBTree2D{ std::move( box_vector ) };
         }
 
         void build_model_stratigraphic_distance_to_mesh_elements(

--- a/src/geode/geosciences/implicit/representation/core/stratigraphic_section.cpp
+++ b/src/geode/geosciences/implicit/representation/core/stratigraphic_section.cpp
@@ -216,13 +216,13 @@ namespace geode
                     "with uuid '",
                     surface.id().string(), "'." );
                 if( !surface.mesh().vertex_attribute_manager().attribute_exists(
-                        stratigraphic_location_attribute_name ) )
+                        STRATIGRAPHIC_LOCATION_ATTRIBUTE_NAME ) )
                 {
                     stratigraphic_location_attributes_.try_emplace(
                         surface.id(),
                         TriangulatedSurfacePointFunction< 2, 1 >::create(
                             surface.mesh< TriangulatedSurface2D >(),
-                            stratigraphic_location_attribute_name,
+                            STRATIGRAPHIC_LOCATION_ATTRIBUTE_NAME,
                             Point1D{ { 0 } } ) );
                 }
                 else
@@ -231,7 +231,7 @@ namespace geode
                         surface.id(),
                         TriangulatedSurfacePointFunction< 2, 1 >::find(
                             surface.mesh< TriangulatedSurface2D >(),
-                            stratigraphic_location_attribute_name ) );
+                            STRATIGRAPHIC_LOCATION_ATTRIBUTE_NAME ) );
                 }
             }
         }
@@ -354,7 +354,7 @@ namespace geode
             auto associated_polygon_edge_attribute =
                 strati_line->edge_attribute_manager()
                     .find_or_create_attribute< VariableAttribute, PolygonEdge >(
-                        stratigraphic_line_polygon_edge_attribute_name, {} );
+                        STRATIGRAPHIC_LINE_POLYGON_EDGE_ATTRIBUTE_NAME, {} );
             const auto& line_mesh = line.mesh();
             std::vector< bool > vertices_checked(
                 line_mesh.nb_vertices(), false );
@@ -410,7 +410,7 @@ namespace geode
                         ->edge_attribute_manager()
                         .find_or_create_attribute< VariableAttribute,
                             PolygonEdge >(
-                            stratigraphic_line_polygon_edge_attribute_name,
+                            STRATIGRAPHIC_LINE_POLYGON_EDGE_ATTRIBUTE_NAME,
                             {} );
             }
             std::vector< bool > vertices_checked(

--- a/src/geode/geosciences/implicit/representation/core/stratigraphic_section.cpp
+++ b/src/geode/geosciences/implicit/representation/core/stratigraphic_section.cpp
@@ -80,7 +80,7 @@ namespace geode
                 model.implicit_value( surface, vertex_id ) };
         }
 
-        absl::optional< StratigraphicPoint2D > stratigraphic_coordinates(
+        std::optional< StratigraphicPoint2D > stratigraphic_coordinates(
             const StratigraphicSection& model,
             const Surface2D& surface,
             const Point2D& geometric_point ) const
@@ -91,7 +91,7 @@ namespace geode
                 return stratigraphic_coordinates( model, surface,
                     geometric_point, containing_polygon.value() );
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         StratigraphicPoint2D stratigraphic_coordinates(
@@ -105,7 +105,7 @@ namespace geode
                 model.implicit_value( surface, geometric_point, triangle_id ) };
         }
 
-        absl::optional< Point2D > geometric_coordinates(
+        std::optional< Point2D > geometric_coordinates(
             const StratigraphicSection& model,
             const Surface2D& surface,
             const StratigraphicPoint2D& stratigraphic_point ) const
@@ -117,7 +117,7 @@ namespace geode
                 return geometric_coordinates( model, surface,
                     stratigraphic_point, containing_polygon.value() );
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         Point2D geometric_coordinates( const StratigraphicSection& model,
@@ -142,7 +142,7 @@ namespace geode
             return geometric_point;
         }
 
-        absl::optional< index_t > stratigraphic_containing_polygon(
+        std::optional< index_t > stratigraphic_containing_polygon(
             const StratigraphicSection& model,
             const Surface2D& surface,
             const StratigraphicPoint2D& stratigraphic_point ) const
@@ -161,7 +161,7 @@ namespace geode
             {
                 return closest_triangle;
             }
-            return absl::nullopt;
+            return std::nullopt;
         }
 
         absl::InlinedVector< std::unique_ptr< EdgedCurve2D >, 2 >
@@ -511,7 +511,7 @@ namespace geode
         return impl_->stratigraphic_coordinates( *this, surface, vertex_id );
     }
 
-    absl::optional< StratigraphicPoint2D >
+    std::optional< StratigraphicPoint2D >
         StratigraphicSection::stratigraphic_coordinates(
             const Surface2D& surface, const Point2D& geometric_point ) const
     {
@@ -528,7 +528,7 @@ namespace geode
             *this, surface, geometric_point, polygon_id );
     }
 
-    absl::optional< Point2D > StratigraphicSection::geometric_coordinates(
+    std::optional< Point2D > StratigraphicSection::geometric_coordinates(
         const Surface2D& surface,
         const StratigraphicPoint2D& stratigraphic_point ) const
     {
@@ -545,7 +545,7 @@ namespace geode
             *this, surface, stratigraphic_point, polygon_id );
     }
 
-    absl::optional< index_t >
+    std::optional< index_t >
         StratigraphicSection::stratigraphic_containing_polygon(
             const Surface2D& surface,
             const StratigraphicPoint2D& stratigraphic_point ) const

--- a/src/geode/geosciences/implicit/representation/core/stratigraphic_section.cpp
+++ b/src/geode/geosciences/implicit/representation/core/stratigraphic_section.cpp
@@ -155,8 +155,8 @@ namespace geode
                         stratigraphic_point.stratigraphic_coordinates(),
                         surface_stratigraphic_distance_to_triangles_.at(
                             surface.id() ) ) );
-            if( std::get< 0 >( surface_stratigraphic_distance_to_triangles_.at(
-                    surface.id() )( stratigraphic_point, closest_triangle ) )
+            if( surface_stratigraphic_distance_to_triangles_.at( surface.id() )(
+                    stratigraphic_point, closest_triangle )
                 < GLOBAL_EPSILON )
             {
                 return closest_triangle;
@@ -295,13 +295,13 @@ namespace geode
             {
             }
 
-            std::tuple< double, Point2D > operator()(
+            double operator()(
                 const StratigraphicPoint2D& query, index_t cur_box ) const
             {
-                return point_triangle_distance< 2 >(
+                return std::get< 0 >( point_triangle_distance< 2 >(
                     query.stratigraphic_coordinates(),
                     PositiveStratigraphicTriangle{ model_, surface_, cur_box }
-                        .positive_triangle_ );
+                        .positive_triangle_ ) );
             }
 
         private:

--- a/src/geode/geosciences/implicit/representation/core/stratigraphic_section.cpp
+++ b/src/geode/geosciences/implicit/representation/core/stratigraphic_section.cpp
@@ -157,7 +157,7 @@ namespace geode
                             surface.id() ) ) );
             if( std::get< 0 >( surface_stratigraphic_distance_to_triangles_.at(
                     surface.id() )( stratigraphic_point, closest_triangle ) )
-                < global_epsilon )
+                < GLOBAL_EPSILON )
             {
                 return closest_triangle;
             }

--- a/src/geode/geosciences/implicit/representation/io/geode/geode_horizons_stack_input.cpp
+++ b/src/geode/geosciences/implicit/representation/io/geode/geode_horizons_stack_input.cpp
@@ -35,8 +35,7 @@ namespace geode
 {
     template < index_t dimension >
     void OpenGeodeHorizonsStackInput< dimension >::load_horizons_stack_files(
-        HorizonsStack< dimension >& horizons_stack,
-        absl::string_view directory )
+        HorizonsStack< dimension >& horizons_stack, std::string_view directory )
     {
         HorizonsStackBuilder< dimension > builder{ horizons_stack };
         async::parallel_invoke(

--- a/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_input.cpp
+++ b/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_input.cpp
@@ -23,9 +23,10 @@
 
 #include <geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_input.h>
 
-#include <async++.h>
+#include <filesystem>
+#include <fstream>
 
-#include <ghc/filesystem.hpp>
+#include <async++.h>
 
 #include <geode/basic/uuid.h>
 #include <geode/basic/zip_file.h>
@@ -58,7 +59,7 @@ namespace geode
         const auto impl_filename = absl::StrCat(
             zip_reader.directory(), "/implicit_section_impl.og_ixsctn" );
         OPENGEODE_EXCEPTION(
-            ghc::filesystem::exists( to_string( impl_filename ) ),
+            std::filesystem::exists( to_string( impl_filename ) ),
             "[OpenGeodeImplicitCrossSectionInput::read] Error in reading "
             "files: Could not find stored impl." );
         std::ifstream file{ impl_filename, std::ifstream::binary };

--- a/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_input.cpp
+++ b/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_input.cpp
@@ -41,7 +41,7 @@
 namespace geode
 {
     void OpenGeodeImplicitCrossSectionInput::load_implicit_cross_section_files(
-        ImplicitCrossSection& section, absl::string_view directory )
+        ImplicitCrossSection& section, std::string_view directory )
     {
         ImplicitCrossSectionBuilder builder{ section };
         builder.set_horizons_stack( load_horizons_stack< 2 >(

--- a/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_output.cpp
+++ b/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_output.cpp
@@ -53,7 +53,7 @@ namespace geode
 
     void OpenGeodeImplicitCrossSectionOutput::save_implicit_section_files(
         const ImplicitCrossSection& implicit_section,
-        absl::string_view directory ) const
+        std::string_view directory ) const
     {
         async::parallel_invoke(
             [&directory, &implicit_section] {

--- a/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_output.cpp
+++ b/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_output.cpp
@@ -23,12 +23,12 @@
 
 #include <geode/geosciences/implicit/representation/io/geode/geode_implicit_cross_section_output.h>
 
+#include <filesystem>
+#include <fstream>
 #include <string>
 #include <vector>
 
 #include <async++.h>
-
-#include <ghc/filesystem.hpp>
 
 #include <geode/basic/uuid.h>
 #include <geode/basic/zip_file.h>
@@ -45,7 +45,7 @@ namespace geode
         const ZipFile& zip_writer ) const
     {
         for( const auto& file :
-            ghc::filesystem::directory_iterator( zip_writer.directory() ) )
+            std::filesystem::directory_iterator( zip_writer.directory() ) )
         {
             zip_writer.archive_file( file.path().string() );
         }

--- a/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_input.cpp
+++ b/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_input.cpp
@@ -23,9 +23,10 @@
 
 #include <geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_input.h>
 
-#include <async++.h>
+#include <filesystem>
+#include <fstream>
 
-#include <ghc/filesystem.hpp>
+#include <async++.h>
 
 #include <geode/basic/uuid.h>
 #include <geode/basic/zip_file.h>
@@ -59,7 +60,7 @@ namespace geode
         const auto impl_filename = absl::StrCat(
             zip_reader.directory(), "/implicit_model_impl.og_istrm" );
         OPENGEODE_EXCEPTION(
-            ghc::filesystem::exists( to_string( impl_filename ) ),
+            std::filesystem::exists( to_string( impl_filename ) ),
             "[OpenGeodeImplicitStructuralModelInput::read] Error in reading "
             "files: Could not find stored impl." );
         std::ifstream file{ impl_filename, std::ifstream::binary };

--- a/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_input.cpp
+++ b/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_input.cpp
@@ -42,7 +42,7 @@ namespace geode
 {
     void OpenGeodeImplicitStructuralModelInput::
         load_implicit_structural_model_files(
-            ImplicitStructuralModel& model, absl::string_view directory )
+            ImplicitStructuralModel& model, std::string_view directory )
     {
         ImplicitStructuralModelBuilder builder{ model };
         builder.set_horizons_stack( std::move( load_horizons_stack< 3 >(

--- a/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_output.cpp
+++ b/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_output.cpp
@@ -23,12 +23,12 @@
 
 #include <geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_output.h>
 
+#include <filesystem>
+#include <fstream>
 #include <string>
 #include <vector>
 
 #include <async++.h>
-
-#include <ghc/filesystem.hpp>
 
 #include <geode/basic/uuid.h>
 #include <geode/basic/zip_file.h>
@@ -45,7 +45,7 @@ namespace geode
         const ZipFile& zip_writer ) const
     {
         for( const auto& file :
-            ghc::filesystem::directory_iterator( zip_writer.directory() ) )
+            std::filesystem::directory_iterator( zip_writer.directory() ) )
         {
             zip_writer.archive_file( file.path().string() );
         }

--- a/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_output.cpp
+++ b/src/geode/geosciences/implicit/representation/io/geode/geode_implicit_structural_model_output.cpp
@@ -53,7 +53,7 @@ namespace geode
 
     void OpenGeodeImplicitStructuralModelOutput::save_implicit_model_files(
         const ImplicitStructuralModel& implicit_model,
-        absl::string_view directory ) const
+        std::string_view directory ) const
     {
         async::parallel_invoke(
             [&directory, &implicit_model] {

--- a/src/geode/geosciences/implicit/representation/io/horizons_stack_input.cpp
+++ b/src/geode/geosciences/implicit/representation/io/horizons_stack_input.cpp
@@ -23,8 +23,9 @@
 
 #include <geode/geosciences/implicit/representation/io/horizons_stack_input.h>
 
+#include <string_view>
+
 #include <absl/strings/str_cat.h>
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/detail/geode_input_impl.h>
 #include <geode/basic/io.h>
@@ -36,7 +37,7 @@
 namespace geode
 {
     template < index_t dimension >
-    HorizonsStack< dimension > load_horizons_stack( absl::string_view filename )
+    HorizonsStack< dimension > load_horizons_stack( std::string_view filename )
     {
         constexpr auto TYPE = "HorizonsStack";
         try
@@ -64,7 +65,7 @@ namespace geode
 
     template < index_t dimension >
     typename HorizonsStackInput< dimension >::MissingFiles
-        check_horizons_stack_missing_files( absl::string_view filename )
+        check_horizons_stack_missing_files( std::string_view filename )
     {
         const auto input = detail::geode_object_input_reader<
             HorizonsStackInputFactory< dimension > >( filename );
@@ -72,7 +73,7 @@ namespace geode
     }
 
     template < index_t dimension >
-    bool is_horizons_stack_loadable( absl::string_view filename )
+    bool is_horizons_stack_loadable( std::string_view filename )
     {
         const auto input = detail::geode_object_input_reader<
             HorizonsStackInputFactory< dimension > >( filename );
@@ -80,19 +81,19 @@ namespace geode
     }
 
     template HorizonsStack< 2 > opengeode_geosciences_implicit_api
-        load_horizons_stack( absl::string_view );
+        load_horizons_stack( std::string_view );
     template HorizonsStack< 3 > opengeode_geosciences_implicit_api
-        load_horizons_stack( absl::string_view );
+        load_horizons_stack( std::string_view );
 
     template HorizonsStackInput< 2 >::MissingFiles
         opengeode_geosciences_implicit_api
-            check_horizons_stack_missing_files< 2 >( absl::string_view );
+            check_horizons_stack_missing_files< 2 >( std::string_view );
     template HorizonsStackInput< 3 >::MissingFiles
         opengeode_geosciences_implicit_api
-            check_horizons_stack_missing_files< 3 >( absl::string_view );
+            check_horizons_stack_missing_files< 3 >( std::string_view );
 
     template bool opengeode_geosciences_implicit_api
-        is_horizons_stack_loadable< 2 >( absl::string_view );
+        is_horizons_stack_loadable< 2 >( std::string_view );
     template bool opengeode_geosciences_implicit_api
-        is_horizons_stack_loadable< 3 >( absl::string_view );
+        is_horizons_stack_loadable< 3 >( std::string_view );
 } // namespace geode

--- a/src/geode/geosciences/implicit/representation/io/horizons_stack_output.cpp
+++ b/src/geode/geosciences/implicit/representation/io/horizons_stack_output.cpp
@@ -24,9 +24,8 @@
 #include <geode/geosciences/implicit/representation/io/horizons_stack_output.h>
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/detail/geode_output_impl.h>
 #include <geode/basic/io.h>
@@ -39,7 +38,7 @@ namespace geode
     template < index_t dimension >
     std::vector< std::string > save_horizons_stack(
         const HorizonsStack< dimension >& horizons_stack,
-        absl::string_view filename )
+        std::string_view filename )
     {
         constexpr auto TYPE = "HorizonsStack";
         try
@@ -61,7 +60,7 @@ namespace geode
     template < index_t dimension >
     bool is_horizons_stack_saveable(
         const HorizonsStack< dimension >& horizons_stack,
-        absl::string_view filename )
+        std::string_view filename )
     {
         const auto output = detail::geode_object_output_writer<
             HorizonsStackOutputFactory< dimension > >( filename );
@@ -69,12 +68,12 @@ namespace geode
     }
 
     template std::vector< std::string > opengeode_geosciences_implicit_api
-        save_horizons_stack( const HorizonsStack< 2 >&, absl::string_view );
+        save_horizons_stack( const HorizonsStack< 2 >&, std::string_view );
     template std::vector< std::string > opengeode_geosciences_implicit_api
-        save_horizons_stack( const HorizonsStack< 3 >&, absl::string_view );
+        save_horizons_stack( const HorizonsStack< 3 >&, std::string_view );
 
     template bool opengeode_geosciences_implicit_api is_horizons_stack_saveable(
-        const HorizonsStack< 2 >&, absl::string_view );
+        const HorizonsStack< 2 >&, std::string_view );
     template bool opengeode_geosciences_implicit_api is_horizons_stack_saveable(
-        const HorizonsStack< 3 >&, absl::string_view );
+        const HorizonsStack< 3 >&, std::string_view );
 } // namespace geode

--- a/src/geode/geosciences/implicit/representation/io/implicit_cross_section_input.cpp
+++ b/src/geode/geosciences/implicit/representation/io/implicit_cross_section_input.cpp
@@ -23,8 +23,9 @@
 
 #include <geode/geosciences/implicit/representation/io/implicit_cross_section_input.h>
 
+#include <string_view>
+
 #include <absl/strings/str_cat.h>
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/detail/geode_input_impl.h>
 #include <geode/basic/io.h>
@@ -38,7 +39,7 @@
 namespace geode
 {
     ImplicitCrossSection load_implicit_cross_section(
-        absl::string_view filename )
+        std::string_view filename )
     {
         constexpr auto TYPE = "ImplicitCrossSection";
         try
@@ -82,14 +83,14 @@ namespace geode
     }
 
     typename ImplicitCrossSectionInput::MissingFiles
-        check_implicit_cross_section_missing_files( absl::string_view filename )
+        check_implicit_cross_section_missing_files( std::string_view filename )
     {
         const auto input = detail::geode_object_input_reader<
             ImplicitCrossSectionInputFactory >( filename );
         return input->check_missing_files();
     }
 
-    bool is_implicit_cross_section_loadable( absl::string_view filename )
+    bool is_implicit_cross_section_loadable( std::string_view filename )
     {
         const auto input = detail::geode_object_input_reader<
             ImplicitCrossSectionInputFactory >( filename );

--- a/src/geode/geosciences/implicit/representation/io/implicit_cross_section_output.cpp
+++ b/src/geode/geosciences/implicit/representation/io/implicit_cross_section_output.cpp
@@ -24,9 +24,8 @@
 #include <geode/geosciences/implicit/representation/io/implicit_cross_section_output.h>
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/detail/geode_output_impl.h>
 #include <geode/basic/io.h>
@@ -40,7 +39,7 @@
 namespace geode
 {
     std::vector< std::string > save_implicit_cross_section(
-        const ImplicitCrossSection& section, absl::string_view filename )
+        const ImplicitCrossSection& section, std::string_view filename )
     {
         constexpr auto TYPE = "ImplicitCrossSection";
         try
@@ -64,7 +63,7 @@ namespace geode
     }
 
     bool is_implicit_cross_section_saveable(
-        const ImplicitCrossSection& section, absl::string_view filename )
+        const ImplicitCrossSection& section, std::string_view filename )
     {
         const auto output = detail::geode_object_output_writer<
             ImplicitCrossSectionOutputFactory >( filename );

--- a/src/geode/geosciences/implicit/representation/io/implicit_structural_model_input.cpp
+++ b/src/geode/geosciences/implicit/representation/io/implicit_structural_model_input.cpp
@@ -23,8 +23,9 @@
 
 #include <geode/geosciences/implicit/representation/io/implicit_structural_model_input.h>
 
+#include <string_view>
+
 #include <absl/strings/str_cat.h>
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/detail/geode_input_impl.h>
 #include <geode/basic/io.h>
@@ -38,7 +39,7 @@
 namespace geode
 {
     ImplicitStructuralModel load_implicit_structural_model(
-        absl::string_view filename )
+        std::string_view filename )
     {
         constexpr auto TYPE = "ImplicitStructuralModel";
         try
@@ -85,14 +86,14 @@ namespace geode
 
     typename ImplicitStructuralModelInput::MissingFiles
         check_implicit_structural_model_missing_files(
-            absl::string_view filename )
+            std::string_view filename )
     {
         const auto input = detail::geode_object_input_reader<
             ImplicitStructuralModelInputFactory >( filename );
         return input->check_missing_files();
     }
 
-    bool is_implicit_structural_model_loadable( absl::string_view filename )
+    bool is_implicit_structural_model_loadable( std::string_view filename )
     {
         const auto input = detail::geode_object_input_reader<
             ImplicitStructuralModelInputFactory >( filename );

--- a/src/geode/geosciences/implicit/representation/io/implicit_structural_model_output.cpp
+++ b/src/geode/geosciences/implicit/representation/io/implicit_structural_model_output.cpp
@@ -24,9 +24,8 @@
 #include <geode/geosciences/implicit/representation/io/implicit_structural_model_output.h>
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/detail/geode_output_impl.h>
 #include <geode/basic/io.h>
@@ -41,7 +40,7 @@ namespace geode
 {
     std::vector< std::string > save_implicit_structural_model(
         const ImplicitStructuralModel& implicit_model,
-        absl::string_view filename )
+        std::string_view filename )
     {
         constexpr auto TYPE = "ImplicitStructuralModel";
         try
@@ -67,7 +66,7 @@ namespace geode
 
     bool is_implicit_structural_model_saveable(
         const ImplicitStructuralModel& implicit_model,
-        absl::string_view filename )
+        std::string_view filename )
     {
         const auto output = detail::geode_object_output_writer<
             ImplicitStructuralModelOutputFactory >( filename );

--- a/src/geode/geosciences/implicit/representation/io/stratigraphic_model_input.cpp
+++ b/src/geode/geosciences/implicit/representation/io/stratigraphic_model_input.cpp
@@ -23,8 +23,9 @@
 
 #include <geode/geosciences/implicit/representation/io/stratigraphic_model_input.h>
 
+#include <string_view>
+
 #include <absl/strings/str_cat.h>
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/detail/geode_input_impl.h>
 #include <geode/basic/io.h>
@@ -38,7 +39,7 @@
 
 namespace geode
 {
-    StratigraphicModel load_stratigraphic_model( absl::string_view filename )
+    StratigraphicModel load_stratigraphic_model( std::string_view filename )
     {
         constexpr auto TYPE = "StratigraphicModel";
         try
@@ -87,7 +88,7 @@ namespace geode
     }
 
     typename StratigraphicModelInput::MissingFiles
-        check_stratigraphic_model_missing_files( absl::string_view filename )
+        check_stratigraphic_model_missing_files( std::string_view filename )
     {
         const auto input =
             detail::geode_object_input_reader< StratigraphicModelInputFactory >(
@@ -95,7 +96,7 @@ namespace geode
         return input->check_missing_files();
     }
 
-    bool is_stratigraphic_model_loadable( absl::string_view filename )
+    bool is_stratigraphic_model_loadable( std::string_view filename )
     {
         const auto input =
             detail::geode_object_input_reader< StratigraphicModelInputFactory >(

--- a/src/geode/geosciences/implicit/representation/io/stratigraphic_model_output.cpp
+++ b/src/geode/geosciences/implicit/representation/io/stratigraphic_model_output.cpp
@@ -24,9 +24,8 @@
 #include <geode/geosciences/implicit/representation/io/stratigraphic_model_output.h>
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/detail/geode_output_impl.h>
 #include <geode/basic/io.h>
@@ -42,7 +41,7 @@ namespace geode
 {
     std::vector< std::string > save_stratigraphic_model(
         const StratigraphicModel& stratigraphic_model,
-        absl::string_view filename )
+        std::string_view filename )
     {
         constexpr auto TYPE = "StratigraphicModel";
         try
@@ -70,7 +69,7 @@ namespace geode
 
     bool is_stratigraphic_model_saveable(
         const StratigraphicModel& stratigraphic_model,
-        absl::string_view filename )
+        std::string_view filename )
     {
         const auto output = detail::geode_object_output_writer<
             StratigraphicModelOutputFactory >( filename );

--- a/src/geode/geosciences/implicit/representation/io/stratigraphic_section_input.cpp
+++ b/src/geode/geosciences/implicit/representation/io/stratigraphic_section_input.cpp
@@ -23,8 +23,9 @@
 
 #include <geode/geosciences/implicit/representation/io/stratigraphic_section_input.h>
 
+#include <string_view>
+
 #include <absl/strings/str_cat.h>
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/detail/geode_input_impl.h>
 #include <geode/basic/io.h>
@@ -38,8 +39,7 @@
 
 namespace geode
 {
-    StratigraphicSection load_stratigraphic_section(
-        absl::string_view filename )
+    StratigraphicSection load_stratigraphic_section( std::string_view filename )
     {
         constexpr auto TYPE = "StratigraphicSection";
         try
@@ -86,14 +86,14 @@ namespace geode
     }
 
     StratigraphicSectionInput::MissingFiles
-        check_stratigraphic_section_missing_files( absl::string_view filename )
+        check_stratigraphic_section_missing_files( std::string_view filename )
     {
         const auto input = detail::geode_object_input_reader<
             StratigraphicSectionInputFactory >( filename );
         return input->check_missing_files();
     }
 
-    bool is_stratigraphic_section_loadable( absl::string_view filename )
+    bool is_stratigraphic_section_loadable( std::string_view filename )
     {
         const auto input = detail::geode_object_input_reader<
             StratigraphicSectionInputFactory >( filename );

--- a/src/geode/geosciences/implicit/representation/io/stratigraphic_section_output.cpp
+++ b/src/geode/geosciences/implicit/representation/io/stratigraphic_section_output.cpp
@@ -24,9 +24,8 @@
 #include <geode/geosciences/implicit/representation/io/stratigraphic_section_output.h>
 
 #include <string>
+#include <string_view>
 #include <vector>
-
-#include <absl/strings/string_view.h>
 
 #include <geode/basic/detail/geode_output_impl.h>
 #include <geode/basic/io.h>
@@ -42,7 +41,7 @@ namespace geode
 {
     std::vector< std::string > save_stratigraphic_section(
         const StratigraphicSection& stratigraphic_section,
-        absl::string_view filename )
+        std::string_view filename )
     {
         constexpr auto TYPE = "StratigraphicSection";
         try
@@ -70,7 +69,7 @@ namespace geode
 
     bool is_stratigraphic_section_saveable(
         const StratigraphicSection& stratigraphic_section,
-        absl::string_view filename )
+        std::string_view filename )
     {
         const auto output = detail::geode_object_output_writer<
             StratigraphicSectionOutputFactory >( filename );

--- a/tests/explicit/test-cross-section.cpp
+++ b/tests/explicit/test-cross-section.cpp
@@ -57,10 +57,10 @@ void add_faults(
         "[Test] Addition of a Fault in CrossSection is not correct" );
 
     const auto& fault1 =
-        builder.add_fault( geode::Fault2D::FAULT_TYPE::REVERSE );
+        builder.add_fault( geode::Fault2D::FAULT_TYPE::reverse );
     builder.set_fault_name( fault1, "fault1" );
     OPENGEODE_EXCEPTION(
-        model.fault( fault1 ).type() == geode::Fault2D::FAULT_TYPE::REVERSE,
+        model.fault( fault1 ).type() == geode::Fault2D::FAULT_TYPE::reverse,
         "[Test] Addition of a Fault in CrossSection is not correct (wrong "
         "type)" );
     OPENGEODE_EXCEPTION( model.nb_faults() == 2,
@@ -77,14 +77,14 @@ void add_horizons(
         "[Test] Addition of a Horizon in CrossSection is not correct" );
 
     const auto& horizon1 =
-        builder.add_horizon( geode::Horizon2D::HORIZON_TYPE::CONFORMAL );
+        builder.add_horizon( geode::Horizon2D::HORIZON_TYPE::conformal );
     OPENGEODE_EXCEPTION( model.horizon( horizon1 ).type()
-                             == geode::Horizon2D::HORIZON_TYPE::CONFORMAL,
+                             == geode::Horizon2D::HORIZON_TYPE::conformal,
         "[Test] Addition of a Horizon in CrossSection is not correct (wrong "
         "type)" );
 
     const auto& horizon2 =
-        builder.add_horizon( geode::Horizon2D::HORIZON_TYPE::NO_TYPE );
+        builder.add_horizon( geode::Horizon2D::HORIZON_TYPE::no_type );
     builder.set_horizon_name( horizon2, "horizon2" );
     OPENGEODE_EXCEPTION( !model.horizon( horizon2 ).has_type(),
         "[Test] Addition of a Horizon in CrossSection is not correct (no "
@@ -398,7 +398,7 @@ void modify_model(
         if( !fault.has_type() )
         {
             builder.set_fault_type(
-                fault.id(), geode::Fault2D::FAULT_TYPE::STRIKE_SLIP );
+                fault.id(), geode::Fault2D::FAULT_TYPE::strike_slip );
         }
         OPENGEODE_EXCEPTION(
             fault.has_type(), "[Test] All faults should have a type" );
@@ -408,7 +408,7 @@ void modify_model(
         if( !horizon.has_type() )
         {
             builder.set_horizon_type(
-                horizon.id(), geode::Horizon2D::HORIZON_TYPE::NON_CONFORMAL );
+                horizon.id(), geode::Horizon2D::HORIZON_TYPE::non_conformal );
         }
         OPENGEODE_EXCEPTION(
             horizon.has_type(), "[Test] All horizons should have a type" );

--- a/tests/explicit/test-geographic-coordinate-system.cpp
+++ b/tests/explicit/test-geographic-coordinate-system.cpp
@@ -41,7 +41,7 @@
 void test_bitsery()
 {
     auto surf = geode::load_triangulated_surface< 2 >(
-        absl::StrCat( geode::data_path, "3patches.og_tsf2d" ) );
+        absl::StrCat( geode::DATA_PATH, "3patches.og_tsf2d" ) );
     auto builder = geode::TriangulatedSurfaceBuilder2D::create( *surf );
     geode::assign_surface_mesh_geographic_coordinate_system_info(
         *surf, *builder, "test", { "EPSG", "2005", "test" } );
@@ -57,26 +57,26 @@ void test_crs()
     OPENGEODE_EXCEPTION(
         infos.size() == 13181, "[Test] Wrong number of supported CRS" );
 
-    constexpr geode::index_t nb_points{ 4 };
+    constexpr geode::index_t NB_POINTS{ 4 };
     geode::AttributeManager manager;
-    manager.resize( nb_points );
+    manager.resize( NB_POINTS );
 
     geode::GeographicCoordinateSystem3D lambert1{ manager,
         { "EPSG", "27571", "I" } };
-    for( const auto p : geode::TRange< double >{ nb_points } )
+    for( const auto p : geode::TRange< double >{ NB_POINTS } )
     {
         lambert1.set_point( p, geode::Point3D{ { p, p, p } } );
     }
     geode::GeographicCoordinateSystem3D lambert2{ manager,
         { "EPSG", "27572", "II" } };
     lambert2.import_coordinates( lambert1 );
-    std::array< geode::Point3D, nb_points > answers{
+    std::array< geode::Point3D, NB_POINTS > answers{
         geode::Point3D{ { 4273.64251995017, 1302920.55457198, 0 } },
         geode::Point3D{ { 4274.63159306906, 1302921.55102308, 1 } },
         geode::Point3D{ { 4275.62066620018, 1302922.54747419, 2 } },
         geode::Point3D{ { 4276.60973934352, 1302923.5439253, 3 } },
     };
-    for( const auto p : geode::Range{ nb_points } )
+    for( const auto p : geode::Range{ NB_POINTS } )
     {
         OPENGEODE_EXCEPTION( lambert2.point( p ).inexact_equal( answers[p] ),
             "[Test] Wrong coordinate conversion" );

--- a/tests/explicit/test-geographic-coordinate-system.cpp
+++ b/tests/explicit/test-geographic-coordinate-system.cpp
@@ -65,7 +65,7 @@ void test_crs()
         { "EPSG", "27571", "I" } };
     for( const auto p : geode::TRange< double >{ nb_points } )
     {
-        lambert1.set_point( p, { { p, p, p } } );
+        lambert1.set_point( p, geode::Point3D{ { p, p, p } } );
     }
     geode::GeographicCoordinateSystem3D lambert2{ manager,
         { "EPSG", "27572", "II" } };

--- a/tests/explicit/test-structural-model.cpp
+++ b/tests/explicit/test-structural-model.cpp
@@ -55,10 +55,10 @@ void add_faults(
         "[Test] Addition of a Fault in StructuralModel is not correct" );
 
     const auto& fault1 =
-        builder.add_fault( geode::Fault3D::FAULT_TYPE::REVERSE );
+        builder.add_fault( geode::Fault3D::FAULT_TYPE::reverse );
     builder.set_fault_name( fault1, "fault1" );
     OPENGEODE_EXCEPTION(
-        model.fault( fault1 ).type() == geode::Fault3D::FAULT_TYPE::REVERSE,
+        model.fault( fault1 ).type() == geode::Fault3D::FAULT_TYPE::reverse,
         "[Test] Addition of a Fault in StructuralModel is not correct (wrong "
         "type)" );
     OPENGEODE_EXCEPTION( model.nb_faults() == 2,
@@ -88,14 +88,14 @@ void add_horizons(
         "[Test] Addition of a Horizon in StructuralModel is not correct" );
 
     const auto& horizon1 =
-        builder.add_horizon( geode::Horizon3D::HORIZON_TYPE::CONFORMAL );
+        builder.add_horizon( geode::Horizon3D::HORIZON_TYPE::conformal );
     OPENGEODE_EXCEPTION( model.horizon( horizon1 ).type()
-                             == geode::Horizon3D::HORIZON_TYPE::CONFORMAL,
+                             == geode::Horizon3D::HORIZON_TYPE::conformal,
         "[Test] Addition of a Horizon in StructuralModel is not correct (wrong "
         "type)" );
 
     const auto& horizon2 =
-        builder.add_horizon( geode::Horizon3D::HORIZON_TYPE::NO_TYPE );
+        builder.add_horizon( geode::Horizon3D::HORIZON_TYPE::no_type );
     builder.set_horizon_name( horizon2, "horizon2" );
     OPENGEODE_EXCEPTION( !model.horizon( horizon2 ).has_type(),
         "[Test] Addition of a Horizon in StructuralModel is not correct (no "
@@ -324,7 +324,7 @@ void modify_model(
         if( !fault.has_type() )
         {
             builder.set_fault_type(
-                fault.id(), geode::Fault3D::FAULT_TYPE::STRIKE_SLIP );
+                fault.id(), geode::Fault3D::FAULT_TYPE::strike_slip );
         }
         OPENGEODE_EXCEPTION(
             fault.has_type(), "[Test] All faults should have a type" );
@@ -334,7 +334,7 @@ void modify_model(
         if( !horizon.has_type() )
         {
             builder.set_horizon_type(
-                horizon.id(), geode::Horizon3D::HORIZON_TYPE::NON_CONFORMAL );
+                horizon.id(), geode::Horizon3D::HORIZON_TYPE::non_conformal );
         }
         OPENGEODE_EXCEPTION(
             horizon.has_type(), "[Test] All horizons should have a type" );

--- a/tests/implicit/test-stratigraphic-model.cpp
+++ b/tests/implicit/test-stratigraphic-model.cpp
@@ -83,23 +83,24 @@ void test_model(
 {
     const auto& block = model.block( block1_id );
     const auto& strati_pt1 = model.stratigraphic_coordinates( block, 59 );
-    OPENGEODE_EXCEPTION( strati_pt1.stratigraphic_coordinates().inexact_equal(
-                             { { -0.213112, -0.188148, 0.472047 } } ),
+    OPENGEODE_EXCEPTION(
+        strati_pt1.stratigraphic_coordinates().inexact_equal(
+            geode::Point3D{ { -0.213112, -0.188148, 0.472047 } } ),
         "[Test] Wrong stratigraphic coordinates for point 59 at position [",
         model.block( block1_id ).mesh().point( 59 ).string(),
         "] with stratigraphic coordinates [", strati_pt1.string(), "]." );
     const geode::Point3D query2{ { 1, 0, 1 } };
     const auto strati_pt2 = model.stratigraphic_coordinates( block, query2 );
     OPENGEODE_EXCEPTION( strati_pt2->stratigraphic_coordinates().inexact_equal(
-                             { { 0.386272, -0.109477, 0. } } ),
+                             geode::Point3D{ { 0.386272, -0.109477, 0. } } ),
         "[Test] Wrong stratigraphic coordinates for point at position [",
         query2.string(), "] with stratigraphic coordinates [",
         strati_pt2->string(), "]." );
     const geode::Point3D query3{ { 0.480373621, 0.5420120955, 0.6765933633 } };
     const auto strati_pt3 = model.stratigraphic_coordinates( block, query3 );
     OPENGEODE_EXCEPTION(
-        strati_pt3->stratigraphic_coordinates().inexact_equal(
-            { { 0.03380647978, -0.002759957825, 0.3080064376 } } ),
+        strati_pt3->stratigraphic_coordinates().inexact_equal( geode::Point3D{
+            { 0.03380647978, -0.002759957825, 0.3080064376 } } ),
         "[Test] Wrong stratigraphic coordinates for point at position [",
         query3.string(), "] with stratigraphic coordinates [",
         strati_pt3->string(), "]." );
@@ -127,10 +128,10 @@ void test_model(
 
     const auto stratigraphic_bbox = model.stratigraphic_bounding_box();
     OPENGEODE_EXCEPTION( stratigraphic_bbox.min().inexact_equal(
-                             { { -0.8098155, -0.5378192, 0 } } ),
+                             geode::Point3D{ { -0.8098155, -0.5378192, 0 } } ),
         "[Test] Wrong stratigraphic coordinates bounding box minimum." );
     OPENGEODE_EXCEPTION( stratigraphic_bbox.max().inexact_equal(
-                             { { 0.5643514, 0.6411656, 1 } } ),
+                             geode::Point3D{ { 0.5643514, 0.6411656, 1 } } ),
         "[Test] Wrong stratigraphic coordinates bounding box minimum." );
 
     for( const auto& horizon : model.horizons() )

--- a/tests/implicit/test-stratigraphic-model.cpp
+++ b/tests/implicit/test-stratigraphic-model.cpp
@@ -241,7 +241,7 @@ int main()
         geode::Logger::info( "Starting test" );
         geode::GeosciencesImplicitLibrary::initialize();
         geode::StratigraphicModel model{ geode::load_structural_model(
-            absl::StrCat( geode::data_path, "vri2.og_strm" ) ) };
+            absl::StrCat( geode::DATA_PATH, "vri2.og_strm" ) ) };
         const geode::uuid block1_id{ "00000000-c271-42e7-8000-00002c3147ed" };
         add_horizons_stack_to_model( model, block1_id );
         test_model( model, block1_id );

--- a/tests/implicit/test-stratigraphic-section.cpp
+++ b/tests/implicit/test-stratigraphic-section.cpp
@@ -50,7 +50,7 @@ geode::StratigraphicSection import_section_with_stratigraphy()
 {
     geode::StratigraphicSection implicit_model{ geode::CrossSection(
         geode::load_section(
-            absl::StrCat( geode::data_path, "test_section.og_sctn" ) ) ) };
+            absl::StrCat( geode::DATA_PATH, "test_section.og_sctn" ) ) ) };
     geode::StratigraphicSectionBuilder model_builder{ implicit_model };
     for( const auto& surface : implicit_model.surfaces() )
     {

--- a/tests/implicit/test-stratigraphic-section.cpp
+++ b/tests/implicit/test-stratigraphic-section.cpp
@@ -61,7 +61,7 @@ geode::StratigraphicSection import_section_with_stratigraphy()
         for( const auto vertex_id : geode::Range{ mesh.nb_vertices() } )
         {
             model_builder.set_stratigraphic_coordinates( surface, vertex_id,
-                { { mesh.point( vertex_id ).value( 0 ),
+                geode::Point2D{ { mesh.point( vertex_id ).value( 0 ),
                     scalar_attribute->value( vertex_id ) } } );
         }
     }
@@ -75,8 +75,8 @@ void test_section( const geode::StratigraphicSection& implicit_model )
     const auto& strati_pt1 =
         implicit_model.stratigraphic_coordinates( surface0, 1773 );
     OPENGEODE_EXCEPTION(
-        strati_pt1.stratigraphic_coordinates().inexact_equal(
-            { { surface0.mesh().point( 1773 ).value( 0 ), -1.940964 } } ),
+        strati_pt1.stratigraphic_coordinates().inexact_equal( geode::Point2D{
+            { surface0.mesh().point( 1773 ).value( 0 ), -1.940964 } } ),
         "[Test] Wrong stratigraphic coordinates for point 1773 at position [",
         surface0.mesh().point( 1773 ).string(),
         "] with stratigraphic coordinates [", strati_pt1.string(), "]." );
@@ -93,17 +93,18 @@ void test_section( const geode::StratigraphicSection& implicit_model )
     const geode::Point2D query3{ { 3.32700324, 4.44508266 } };
     const auto strati_pt3 =
         implicit_model.stratigraphic_coordinates( surface0, query3 );
-    OPENGEODE_EXCEPTION( strati_pt3->stratigraphic_coordinates().inexact_equal(
-                             { { query3.value( 0 ), -1.889619 } } ),
+    OPENGEODE_EXCEPTION(
+        strati_pt3->stratigraphic_coordinates().inexact_equal(
+            geode::Point2D{ { query3.value( 0 ), -1.889619 } } ),
         "[Test] Wrong stratigraphic coordinates for point at position [",
         query3.string(), "] with stratigraphic coordinates [",
         strati_pt3->string(), "]." );
     const auto stratigraphic_bbox = implicit_model.stratigraphic_bounding_box();
-    OPENGEODE_EXCEPTION(
-        stratigraphic_bbox.min().inexact_equal( { { 0, -6.5798343 } } ),
+    OPENGEODE_EXCEPTION( stratigraphic_bbox.min().inexact_equal(
+                             geode::Point2D{ { 0, -6.5798343 } } ),
         "[Test] Wrong stratigraphic coordinates bounding box minimum." );
-    OPENGEODE_EXCEPTION(
-        stratigraphic_bbox.max().inexact_equal( { { 15, 10.4703907 } } ),
+    OPENGEODE_EXCEPTION( stratigraphic_bbox.max().inexact_equal(
+                             geode::Point2D{ { 15, 10.4703907 } } ),
         "[Test] Wrong stratigraphic coordinates bounding box minimum." );
 }
 

--- a/tests/tests_config.h.in
+++ b/tests/tests_config.h.in
@@ -28,5 +28,5 @@
 namespace geode
 {
     /* Absolute path to test source directory */
-    static constexpr auto data_path = "@DATA_DIRECTORY@/";
+    static constexpr auto DATA_PATH = "@DATA_DIRECTORY@/";
 } // namespace geode


### PR DESCRIPTION
Renaming global_epsilon to GLOBAL_EPSILON, global_angular_epsilon to GLOBAL_ANGULAR_EPSILON and all enum names (uppercase names).